### PR TITLE
feat: define an extensions section of the manifest

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -453,7 +453,7 @@ Implementations that do not support custom actions MUST NOT emit errors (either 
 
 In many cases, the bundle descriptor is a sufficient artifact for delivering a CNAB bundle, since invocation images and other images may be retrieved from registries and repositories. Consequently, it is important to provide an extension mechanism. An _extension_ is a named collection of auxiliary data whose meaning is defined outside of this specification.
 
-Tools _may_ define and declare additional fields inside of the `extension` section. Tools _must not_ define additional fields anywhere else in the bundle descriptor. Implementations _may_ produce an error or _may_ ignore additional fields outside of the extension. However, implementations _should_ preserve the data inside of the `extensions` section even when that information is not understood by the implementation.
+Tools MAY define and declare additional fields inside of the `extensions` section. Tools MUST NOT define additional fields anywhere else in the bundle descriptor. Implementations MAY produce an error or MAY ignore additional fields outside of the extension. However, implementations SHOULD preserve the data inside of the `extensions` section even when that information is not understood by the implementation.
 
 The `extensions` 
 
@@ -484,10 +484,18 @@ The format is:
 The fields are defined as follows:
 
 - `extensions` defines the wrapper object for extensions
-  - EXTENSION NAME: a unique name for an extension. Names _should_ follow the format `DOMAIN/PATH`, where DOMAIN conforms to the DNS naming convention, and path elements are separated by forward slashes (`/`).
+  - EXTENSION NAME: a unique name for an extension. Names SHOULD follow the format `DOMAIN/PATH`, where DOMAIN conforms to the DNS naming convention, and path elements are separated by forward slashes (`/`).
   - The value of the extension must be valid JSON, but is otherwise undefined.
 
-The usage of extensions is undefined. However, bundles _should_ be installable by runtimes that do not understand the extensions.
+The usage of extensions is undefined. However, bundles SHOULD be installable by runtimes that do not understand the extensions.
+
+### Additional Files
+
+The CNAB core specification does not define files in addition to the bundle descriptor, the exported bundle, and (to a lesser degree) the invocation images.
+
+The specification does not prohibit runtimes or tools from using external files for auxiliary purposes. However, a conformant CNAB bundle MUST be executable without extra files. Thus, extensions MAY incorporate other files.
+
+It is beyond the scope of the specification to determine how those files are to be transmitted, stored, or retrieved.
 
 
 Next section: [The invocation image definition](102-invocation-image.md)

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -69,6 +69,11 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
             "path": "/etc/hostkey.txt",
             "env": "HOST_KEY"
         }
+    },
+    "extensions": {
+        "deislabs.io/duffle-bag": {
+            "icon": "https://example.com/icon.png"
+        }
     }
 }
 ```
@@ -127,6 +132,12 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
             "path": "/etc/hostkey.txt",
             "env": "HOST_KEY"
         }
+    },
+    "extensions": {
+        "deislabs.io/duffle-bag": {
+            "icon": "https://example.com/icon.png"
+        }
+    }
 }
 ```
 
@@ -437,6 +448,47 @@ An invocation image _ought_ to handle all custom targets declared in the `action
 The built-in actions (`install`, `upgrade`, `uninstall`) MUST NOT appear in the `actions` section, and an implementation MUST NOT allow custom actions named `install`, `upgrade`, or `uninstall`.
 
 Implementations that do not support custom actions MUST NOT emit errors (either runtime or validation) if a bundle defines custom actions. That is, even if an implementation cannot execute custom actions, it MUST NOT fail to operate on bundles that declare custom actions.
+
+## Extensions
+
+In many cases, the bundle descriptor is a sufficient artifact for delivering a CNAB bundle, since invocation images and other images may be retrieved from registries and repositories. Consequently, it is important to provide an extension mechanism. An _extension_ is a named collection of auxiliary data whose meaning is defined outside of this specification.
+
+Tools _may_ define and declare additional fields inside of the `extension` section. Tools _must not_ define additional fields anywhere else in the bundle descriptor. Implementations _may_ produce an error or _may_ ignore additional fields outside of the extension. However, implementations _should_ preserve the data inside of the `extensions` section even when that information is not understood by the implementation.
+
+The `extensions` 
+
+```json
+{
+    "extensions": {
+        "example.com/duffle-bag": {
+            "icon": "https://example.com/icon.png",
+            "iconType": "PNG"
+        },
+        "example.com/backup-preferences": {
+            "frequency": "daily"
+        }
+    }
+}
+```
+
+The format is:
+
+```json
+{
+    "extensions": {
+        "EXTENSION NAME": "ARBITRARY JSON DATA"
+    }
+}
+```
+
+The fields are defined as follows:
+
+- `extensions` defines the wrapper object for extensions
+  - EXTENSION NAME: a unique name for an extension. Names _should_ follow the format `DOMAIN/PATH`, where DOMAIN conforms to the DNS naming convention, and path elements are separated by forward slashes (`/`).
+  - The value of the extension must be valid JSON, but is otherwise undefined.
+
+The usage of extensions is undefined. However, bundles _should_ be installable by runtimes that do not understand the extensions.
+
 
 Next section: [The invocation image definition](102-invocation-image.md)
 

--- a/901-process.md
+++ b/901-process.md
@@ -6,7 +6,7 @@ While CNAB has not officially been assigned to a standards body, it is good prac
 
 Specifications shall each track their own versions, where a version is [semantically versioned](https://semver.org).
 
-The CNAB Core specification shall therefore be formally referenced as _Cloud Native Application Bundle Core 1.0.0_. The phase of the process _may_ be appended as a stability marker: _Cloud Native Application Bundle Core 1.0.0-WD_. It _may_ be abbreviated to _CNAB1_.
+The CNAB Core specification shall therefore be formally referenced as _Cloud Native Application Bundle Core 1.0.0_. The phase of the process MAY be appended as a stability marker: _Cloud Native Application Bundle Core 1.0.0-WD_. It MAY be abbreviated to _CNAB1_.
 
 ## Process
 


### PR DESCRIPTION
This defines a section of the manifest where arbitrary extensions can be added.

The goal of this section is to provide a specific location for extension data to be defined such that we don't end up like `package.json`, where tons of ad hoc extensions have been added to the root document.