### PR TITLE
Introduce image map injection

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -10,7 +10,7 @@ A `bundle.json` is broken down into the following categories of information:
     - version: Semantic version of the bundle
     - description: Short description of the bundle
 - Information on the invocation images, as an array
-- A list of images included with this bundle, as an array
+- A map of images included with this bundle, as a `component name` to `image definition` map
 - A specification of which parameters MAY be overridden, and how those are to be validated
 - A list of credentials (name and desired location) that the application needs
 - An OPTIONAL description of custom actions that this bundle implements
@@ -41,8 +41,8 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
             "digest": "sha256:aaaaaaa..."
         }
     ],
-    "images": [
-        {
+    "images": {
+        "my-microservice": {
             "image": "technosophos/microservice:1.2.3",
             "description": "my microservice",
             "digest": "sha256:aaaaaaaaaaaa...",
@@ -54,7 +54,7 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
                 }
             ]
         }
-    ],
+    },
     "parameters": {
         "backend_port" : {
             "type" : "int",
@@ -102,8 +102,8 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
             }
         }
     ],
-    "images": [
-        {
+    "images": {
+        "my-microservice": {
             "image": "technosophos/helloworld:0.1.2",
             "description": "helloworld microservice",
             "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
@@ -114,7 +114,7 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
                 "os": "linux"
             }
         }
-    ],
+    },
     "parameters": {
         "backend_port" : {
             "type" : "int",
@@ -196,7 +196,7 @@ The following OPTIONAL fields MAY be attached to an invocation image:
   - `os`: The operating system of the image
 - `mediaType`: The media type of the image
 
-## The Image List
+## The Image Map
 
 The `bundle.json` maps image metadata (name, origin, tag) to placeholders within the bundle. This allows images to be renamed, relabeled, or replaced during the CNAB bundle build operation. It also specifies the parameters that MAY be overridden in this image, giving tooling the ability to expose configuration options.
 
@@ -204,9 +204,9 @@ The following illustrates an `images` section:
 
 ```json
 {
-"images": [
-        { 
-            "description": "frontend",
+"images": {
+        "frontend": { 
+            "description": "frontend component image",
             "imageType": "docker",
             "image": "gabrtv.azurecr.io/gabrtv/vote-frontend:a5ff67...",
             "digest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
@@ -217,8 +217,8 @@ The following illustrates an `images` section:
                 }
             ]
         },
-        {
-            "description": "backend",
+        "backend": {
+            "description": "backend component image",
             "imageType": "docker",
             "digest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
             "image": "gabrtv.azurecr.io/gabrtv/vote-backend:a5ff67...",
@@ -229,14 +229,14 @@ The following illustrates an `images` section:
                 }
             ]
         }
-    ]
+    }
 }
 ```
 
 Fields:
 
 - images: The list of dependent images
-  - `description`: The description field provides additional context of the purpose of the image.
+  - `description`: The description field provides additional context of the purpose of the image. 
   - `imageType`: The `imageType` field MUST describe the format of the image. The list of formats is open-ended, but any CNAB-compliant system MUST implement `docker` and `oci`. The default is `oci`.
   - `image`: The REQUIRED `image` field provides a valid reference (REGISTRY/NAME:TAG) for the image. Note that SHOULD be a CAS SHA, not a version tag as in the example above.
   - `digest`: MUST contain a digest, in [OCI format](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#digests), to be used to compute the integrity of the image. The calculation of how the image matches the digest is dependent upon image type. (OCI, for example, uses a Merkle tree while VM images are checksums.)
@@ -255,6 +255,8 @@ Substitutions MUST be supported for the following formats:
 - JSON
 - YAML
 - XML
+
+In addition to these substitutions, the image map data is also made available to the invocation image at runtime. See [Image map](103-bundle-runtime.md#image-map) for more details.
 
 ### Field Selectors
 

--- a/102-invocation-image.md
+++ b/102-invocation-image.md
@@ -3,7 +3,7 @@
 The `invocationImages` section of a `bundle.json` MUST contain at least one image (the invocation image). This image MUST be formatted according to the specification laid out in the present document.
 The appropriate invocation image is selected using the current driver.
 
-When a bundle is executed, the invocation image will be retrieved (if necessary) and started. Credential and parameter data is passed to it, and then its `run` tool is executed. (See [The Bundle Runtime](103-bundle-runtime.md) for details).
+When a bundle is executed, the invocation image will be retrieved (if necessary) and started. Credential, parameter and image map data is passed to it, and then its `run` tool is executed. (See [The Bundle Runtime](103-bundle-runtime.md) for details).
 
 This section describes the layout of an invocation image.
 

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -141,4 +141,91 @@ Credentials MAY be supplied as files on the file system. In such cases, the foll
 - If a file's permissions or metadata is incorrect, the run tool MAY try to remediate (e.g. run `chmod`), or MAY cause a fatal error
 - The run tool MAY modify credential files. Consequently, any runtime implementation MUST ensure that credentials changed inside of the invocation image will not result in modifications to the source.
 
+## <a name="image-map">Image maps</a>
+
+At runtime the `image` section of the CNAB is mounted in file `/cnab/app/image-map.json`. 
+For this example CNAB bundle:
+
+```json
+{
+    "schemaVersion": "v1.0.0-WD",
+    "name": "helloworld",
+    "version": "0.1.2",
+    "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
+    "maintainers": [
+        {
+            "name": "Matt Butcher",
+            "email": "technosophos@gmail.com",
+            "url": "https://example.com"
+        }
+    ],
+    "invocationImages": [
+        {
+            "imageType": "docker",
+            "image": "technosophos/helloworld:0.1.0",
+            "digest": "sha256:aaaaaaa..."
+        }
+    ],
+    "images": {
+        "my-microservice": {
+            "image": "technosophos/microservice:1.2.3",
+            "description": "my microservice",
+            "digest": "sha256:aaaaaaaaaaaa...",
+            "uri": "urn:image1uri",
+            "refs": [
+                {
+                    "path": "image1path",
+                    "field": "image.1.field"
+                }
+            ]
+        }
+    },
+    "parameters": {
+        "backend_port" : {
+            "type" : "int",
+            "defaultValue": 80,
+            "minValue": 10,
+            "maxValue": 10240,
+            "metadata": {
+               "description": "The port that the back-end will listen on"
+            }
+        }
+    },
+    "credentials": {
+        "kubeconfig": {
+            "path": "/home/.kube/config",
+        },
+        "image_token": {
+            "env": "AZ_IMAGE_TOKEN",
+        },
+        "hostkey": {
+            "path": "/etc/hostkey.txt",
+            "env": "HOST_KEY"
+        }
+    }
+}
+```
+
+The `/cnab/app/image-map.json` file mounted in the invocation image will be:
+
+```json
+{    
+    "my-microservice": {
+        "image": "technosophos/microservice:1.2.3",
+        "description": "my microservice",
+        "digest": "sha256:aaaaaaaaaaaa...",
+        "uri": "urn:image1uri",
+        "refs": [
+            {
+                "path": "image1path",
+                "field": "image.1.field"
+            }
+        ]
+    }
+}
+ 
+```
+
+The run tool MAY use this file to modify its behavior, if declarative substitution is not enough.
+
 Next Section: [The claims definition](104-claims.md)


### PR DESCRIPTION
This brings 2 changes:
- Bundle.json `images` field is now a map (`component logical name` -> `image definition`)
- `images` map is injected at runtime so that the invocation image can use it when declarative substitutions are not applicable

Relates to discussion in #58