### PR TITLE
fix: remove `digest` field from image and invocationImage specs.

### DIFF
--- a/105-signing.md
+++ b/105-signing.md
@@ -40,7 +40,7 @@ sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b
 
 CNAB is composed of a `bundle.json` and a number of supporting images. Those images are referenced by the `bundle.json`. Thus, digesting those artifacts and including their digest in the `bundle.json` provides a convenient way to store (and locate) digests.
 
-To that end, in a signed bundle, anything that shows up in the `invocationImages` or `images` section of the `bundle.json` MUST have a digest attached to the image:
+To that end, in a signed bundle, anything that shows up in the `invocationImages` or `images` section of the `bundle.json` MUST have a digested image reference:
 
 ```json
 {

--- a/105-signing.md
+++ b/105-signing.md
@@ -67,7 +67,7 @@ To that end, in a signed bundle, anything that shows up in the `invocationImages
 }
 ```
 
-Non-OCI images may still append digests using the `@DIGESET` form above. A runtime must be able to translate such a reference to the appropriate image, and perform the appropriate validation.
+Non-OCI images may still append digests using the `@DIGEST` form above. A runtime must be able to translate such a reference to the appropriate image, and perform the appropriate validation.
 
 Different formats (viz. OCI) provide definitions for validating a digest. Images SHOULD be validated using these definitions, according to their `imageType`. If a particular image type does not already define what it means to have a digest verified, the default method is to retrieve the object as-is, and checksum it in the format in which it was delivered when accessed.
 

--- a/105-signing.md
+++ b/105-signing.md
@@ -40,7 +40,7 @@ sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b
 
 CNAB is composed of a `bundle.json` and a number of supporting images. Those images are referenced by the `bundle.json`. Thus, digesting those artifacts and including their digest in the `bundle.json` provides a convenient way to store (and locate) digests.
 
-To that end, in a signed bundle, anything that shows up in the `invocationImages` or `images` section of the `bundle.json` MUST have a `digest`:
+To that end, in a signed bundle, anything that shows up in the `invocationImages` or `images` section of the `bundle.json` MUST have a digest attached to the image:
 
 ```json
 {
@@ -49,14 +49,12 @@ To that end, in a signed bundle, anything that shows up in the `invocationImages
     "invocationImages": [
         {
             "imageType": "docker",
-            "image": "technosophos/helloworld:0.1.0",
-            "digest": "sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b"
+            "image": "technosophos/helloworld:0.1.0@sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b",
         }
     ],
     "images": [
         {
-            "name": "image1",
-            "digest": "sha256:aaaa624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b",
+            "name": "image1@sha256:aaaa624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b",
             "uri": "urn:image1uri",
             "refs": [
                 {
@@ -69,11 +67,9 @@ To that end, in a signed bundle, anything that shows up in the `invocationImages
 }
 ```
 
-Objects MUST contain a `digest` field even if the digest is present in another field. This is done to provide _access uniformity_.
+Non-OCI images may still append digests using the `@DIGESET` form above. A runtime must be able to translate such a reference to the appropriate image, and perform the appropriate validation.
 
-> OCI images, for example, MAY embed a digest in the image's _version_ field. According to this specification, while this is allowed, it does not remove the requirement that the `digest` field be present and filled.
-
-Different formats (viz. OCI) provide definitions for validating a digest. When possible, images should be validated using these definitions, according to their `imageType`. If a particular image type does not already define what it means to have a digest verified, the default method is to retrieve the object as-is, and checksum it in the format in which it was delivered when accessed.
+Different formats (viz. OCI) provide definitions for validating a digest. Images SHOULD be validated using these definitions, according to their `imageType`. If a particular image type does not already define what it means to have a digest verified, the default method is to retrieve the object as-is, and checksum it in the format in which it was delivered when accessed.
 
 Drivers MAY choose to accept the digesting by another trusted agent in lieu of performing the digest algorithm themselves. For example, if a driver requests that a remote agent install an image on its behalf, it MAY trust that the image digest given by that remote agent is indeed the digest of the object in question. And it MAY then compare that digest to the `bundle.json`'s digest. In such cases, a driver SHOULD ensure that the channel between the driver itself and the trusted remote agent is itself secured (for example, via TLS). Failure to do so will invalidate the integrity of the check.
 
@@ -117,8 +113,7 @@ For example, here is a `bundle.json`:
     "invocationImages": [
         {
             "imageType": "docker",
-            "image": "technosophos/helloworld:0.1.2",
-            "digest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685"
+            "image": "technosophos/helloworld:0.1.2@sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685"
         }
     ],
     "images": [],
@@ -139,8 +134,7 @@ Hash: SHA512
     "invocationImages": [
         {
             "imageType": "docker",
-            "image": "technosophos/helloworld:0.1.2",
-            "digest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685"
+            "image": "technosophos/helloworld:0.1.2@sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685"
         }
     ],
     "images": [],

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -117,10 +117,6 @@
                     "type": "string",
                     "default": "oci"
                 },
-                "digest":{
-                    "description": "A cryptographic hash digest that can be used to validate the image. This may be interpreted differently based on imageType",
-                    "type": "string"
-                },
                 "size": {
                     "description": "The image size in bytes",
                     "type":"integer"
@@ -162,10 +158,6 @@
                     "description": "The type of image. If this is not specified, 'oci' is assumed",
                     "type": "string",
                     "default": "oci"
-                },
-                "digest":{
-                    "description": "A cryptographic hash digest that can be used to validate the image. This may be interpreted differently based on imageType",
-                    "type": "string"
                 },
                 "size": {
                     "description": "The image size in bytes",


### PR DESCRIPTION
This moves the digest into the `image` field following the Docker method of embedding it with `@DIGEST`. Using this method will have some consequences for other image types (notably VM images). So we should be sure about this before committing.

Closes #61