### PR TITLE
Clarify use of semver

### DIFF
--- a/100-CNAB.md
+++ b/100-CNAB.md
@@ -1,5 +1,5 @@
 # Cloud Native Application Bundle Core 1.0.0 (CNAB1)
-*Working Draft, Nov. 2018*
+*[Working Draft](901-process.md), Nov. 2018*
 
 
 The Cloud Native Application Bundle (CNAB) is a _standard packaging format_ for multi-component distributed applications. It allows packages to target different runtimes and architectures. It empowers application distributors to package applications for deployment on a wide variety of cloud platforms, providers, and services. Furthermore, it provides necessary capabilities for delivering multi-container applications in disconnected (airgapped) environments.

--- a/901-process.md
+++ b/901-process.md
@@ -4,7 +4,7 @@ While CNAB has not officially been assigned to a standards body, it is good prac
 
 ## Versioning
 
-Specifications shall each track their own versions. A specifiction will call out a target version (such as 1.0), and then also include its phase (such as Working Draft, see below) to indicate progress towards the target version.
+Specifications shall each track their own versions. A specification will call out a target version (such as 1.0), and then also include its phase (such as Working Draft, see below) to indicate progress towards the target version.
 
 The CNAB Core specification shall therefore be formally referenced as _Cloud Native Application Bundle Core 1.0.0_. The phase of the process _may_ be appended as a stability marker: _Cloud Native Application Bundle Core 1.0.0-WD_. It _may_ be abbreviated to _CNAB1_.
 

--- a/901-process.md
+++ b/901-process.md
@@ -4,7 +4,7 @@ While CNAB has not officially been assigned to a standards body, it is good prac
 
 ## Versioning
 
-Specifications shall each track their own versions, where a version is [semantically versioned](https://semver.org).
+Specifications shall each track their own versions. A specifiction will call out a target version (such as 1.0), and then also include its phase (such as Working Draft, see below) to indicate progress towards the target version.
 
 The CNAB Core specification shall therefore be formally referenced as _Cloud Native Application Bundle Core 1.0.0_. The phase of the process _may_ be appended as a stability marker: _Cloud Native Application Bundle Core 1.0.0-WD_. It _may_ be abbreviated to _CNAB1_.
 


### PR DESCRIPTION
* Link to the definition of WD from the spec
* Remove text saying that we use semver
* Explain that the version is a _target_ that is applied before we hit it