### PR TITLE
Introduce namespaced custom actions

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -466,14 +466,14 @@ Implementations MAY support user-defined additional actions as well. Such action
 
 ```json
 "actions": {
-    "status":{
+    "io.cnab.status":{
         "modifies": false,
         "description": "retrieves the status of an installation"
     },
-    "migrate":{
+    "io.cnab.migrate":{
         "modifies": false
     },
-    "dry-run":{
+    "io.cnab.dry-run":{
         "modifies": false,
         "stateless": true,
         "description": "prints what install would do with the given parameters values"
@@ -481,7 +481,9 @@ Implementations MAY support user-defined additional actions as well. Such action
 }
 ```
 
-The above declares to actions: `status` and `migrate`. This means that the associated invocation images can handle requests for `status` and `migrate` in addition to `install`, `upgrade`, and `uninstall`.
+The action _name_ SHOULD be namespaced and SHOULD use reverse DNS notation - e.g. `com.example.action`. 
+
+The above declares three actions: `io.cnab.status`, `io.cnab.migrate` and `io.cnab.dry-run`. This means that the associated invocation images can handle requests for `io.cnab.status`, `io.cnab.migrate` and `io.cnab.dry-run` in addition to `install`, `upgrade`, and `uninstall`.
 
 Each action is accompanied by a description, which contains the following fields:
 

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -78,7 +78,7 @@
             }
         },
         "actions":{
-            "description": "Custom actions that can be triggered on this bundle",
+            "description": "Custom actions that can be triggered on this bundle, action name should be namespaced and use reverse DNS notation",
             "type": "object",
             "additionalProperties": {
                 "type": "object",


### PR DESCRIPTION
With the multiplication of CNAB runtime implementations, it may occur some custom action clash as multiple runtimes will define different actions using the same name (eg `status`).

I guess it is not be a problem for read-only (`"modifies": false`) actions, but for the others the semantic may change dramatically depending the runtime.

To tackle this problem I suggest we add the following line to the spec:
```
The action name SHOULD be namespaced by the CNAB implementation which generated the bundle.
```
so runtimes will be able to resolve correctly their own custom actions (or if they decide to support custom actions from other runtimes).