### PR TITLE
Intoduce action-specific parameters

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -288,7 +288,8 @@ The `parameters` section of the `bundle.json` defines which parameters a user (p
         "destination": {
             "env": "MY_ENV_VAR",
             "path": "/my/destination/path"
-        }
+        },
+        "apply-to": ["install", "action1", "action2"]
     }
 }
 ```
@@ -309,6 +310,7 @@ The `parameters` section of the `bundle.json` defines which parameters a user (p
     - destination: Indicates where (in the invocation image) the parameter is to be written (REQUIRED)
       - env: The name of an environment variable
       - path: The fully qualified path to a file that will be created
+    - apply-to: restricts this parameter to a given list of actions. If empty or missing, applies to all actions (OPTIONAL)
 
 Parameter names (the keys in `parameters`) ought to conform to the [Open Group Base Specification Issue 6, Section 8.1, paragraph 4](http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html) definition of environment variable names with one exception: parameter names MAY begin with a digit (approximately `[A-Z0-9_]+`).
 
@@ -385,7 +387,8 @@ The structure of a parameters section looks like this:
         "destination": {
             "env": "<name-of-env-var>",
             "path": "<fully-qualified-path>"
-        }
+        },
+        "apply-to": ["action1", "action2"]
     }
 }
 ```

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -308,6 +308,10 @@
                             "type": "string"
                         }
                     }
+                },
+                "apply-to":{                    
+                    "description": "An optional exhaustive list of actions handling this parameter",
+                    "type":"array"
                 }
             },
             "required": ["type", "destination"]

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -311,7 +311,10 @@
                 },
                 "apply-to":{                    
                     "description": "An optional exhaustive list of actions handling this parameter",
-                    "type":"array"
+                    "type":"array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "required": ["type", "destination"]


### PR DESCRIPTION
This adds an optional "apply-to" field to parameters definition to make
a parameter usable only for a specific set of actions.

eg.: we could have a `follow` parameter that could only apply to the
`logs` custom action of a CNAB (as it only makes sense in the context of
this action)
