### PR TITLE
Bundle extension fields through `custom`

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -502,22 +502,22 @@ The built-in actions (`install`, `upgrade`, `uninstall`) MUST NOT appear in the 
 
 Implementations that do not support custom actions MUST NOT emit errors (either runtime or validation) if a bundle defines custom actions. That is, even if an implementation cannot execute custom actions, it MUST NOT fail to operate on bundles that declare custom actions.
 
-## Extensions
+## Custom Extensions
 
-In many cases, the bundle descriptor is a sufficient artifact for delivering a CNAB bundle, since invocation images and other images may be retrieved from registries and repositories. Consequently, it is important to provide an extension mechanism. An _extension_ is a named collection of auxiliary data whose meaning is defined outside of this specification.
+In many cases, the bundle descriptor is a sufficient artifact for delivering a CNAB bundle, since invocation images and other images may be retrieved from registries and repositories. Consequently, it is important to provide an extension mechanism. A _custom extension_ is a named collection of auxiliary data whose meaning is defined outside of this specification.
 
-Tools MAY define and declare additional fields inside of the `extensions` section. Tools MUST NOT define additional fields anywhere else in the bundle descriptor. Implementations MAY produce an error or MAY ignore additional fields outside of the extension. However, implementations SHOULD preserve the data inside of the `extensions` section even when that information is not understood by the implementation.
+Tools MAY define and declare additional fields inside of the `custom` section. Tools MUST NOT define additional fields anywhere else in the bundle descriptor. Implementations may produce an error or may ignore additional fields outside of the extension. However, implementations SHOULD preserve the data inside of the `custom` section even when that information is not understood by the implementation.
 
-The `extensions` 
+The `custom` object is used as follows:
 
 ```json
 {
-    "extensions": {
-        "example.com/duffle-bag": {
+    "custom": {
+        "com.example.duffle-bag": {
             "icon": "https://example.com/icon.png",
             "iconType": "PNG"
         },
-        "example.com/backup-preferences": {
+        "com.example.backup-preferences": {
             "frequency": "daily"
         }
     }
@@ -537,18 +537,10 @@ The format is:
 The fields are defined as follows:
 
 - `extensions` defines the wrapper object for extensions
-  - EXTENSION NAME: a unique name for an extension. Names SHOULD follow the format `DOMAIN/PATH`, where DOMAIN conforms to the DNS naming convention, and path elements are separated by forward slashes (`/`).
+  - EXTENSION NAME: a unique name for an extension. Names SHOULD follow the reverse DNS format `DOMAIN.ADDITIONAL.INFORMATION`, where DOMAIN conforms to the reverse DNS naming convention (`com.example` or `io.cnab`), and additional elements are separated by dots (`.`).
   - The value of the extension must be valid JSON, but is otherwise undefined.
 
 The usage of extensions is undefined. However, bundles SHOULD be installable by runtimes that do not understand the extensions.
-
-### Additional Files
-
-The CNAB core specification does not define files in addition to the bundle descriptor, the exported bundle, and (to a lesser degree) the invocation images.
-
-The specification does not prohibit runtimes or tools from using external files for auxiliary purposes. However, a conformant CNAB bundle MUST be executable without extra files. Thus, extensions MAY incorporate other files.
-
-It is beyond the scope of the specification to determine how those files are to be transmitted, stored, or retrieved.
 
 
 Next section: [The invocation image definition](102-invocation-image.md)

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -506,7 +506,7 @@ Implementations that do not support custom actions MUST NOT emit errors (either 
 
 In many cases, the bundle descriptor is a sufficient artifact for delivering a CNAB bundle, since invocation images and other images may be retrieved from registries and repositories. Consequently, it is important to provide an extension mechanism. An _extension_ is a named collection of auxiliary data whose meaning is defined outside of this specification.
 
-Tools _may_ define and declare additional fields inside of the `extension` section. Tools _must not_ define additional fields anywhere else in the bundle descriptor. Implementations _may_ produce an error or _may_ ignore additional fields outside of the extension. However, implementations _should_ preserve the data inside of the `extensions` section even when that information is not understood by the implementation.
+Tools MAY define and declare additional fields inside of the `extensions` section. Tools MUST NOT define additional fields anywhere else in the bundle descriptor. Implementations MAY produce an error or MAY ignore additional fields outside of the extension. However, implementations SHOULD preserve the data inside of the `extensions` section even when that information is not understood by the implementation.
 
 The `extensions` 
 
@@ -537,10 +537,18 @@ The format is:
 The fields are defined as follows:
 
 - `extensions` defines the wrapper object for extensions
-  - EXTENSION NAME: a unique name for an extension. Names _should_ follow the format `DOMAIN/PATH`, where DOMAIN conforms to the DNS naming convention, and path elements are separated by forward slashes (`/`).
+  - EXTENSION NAME: a unique name for an extension. Names SHOULD follow the format `DOMAIN/PATH`, where DOMAIN conforms to the DNS naming convention, and path elements are separated by forward slashes (`/`).
   - The value of the extension must be valid JSON, but is otherwise undefined.
 
-The usage of extensions is undefined. However, bundles _should_ be installable by runtimes that do not understand the extensions.
+The usage of extensions is undefined. However, bundles SHOULD be installable by runtimes that do not understand the extensions.
+
+### Additional Files
+
+The CNAB core specification does not define files in addition to the bundle descriptor, the exported bundle, and (to a lesser degree) the invocation images.
+
+The specification does not prohibit runtimes or tools from using external files for auxiliary purposes. However, a conformant CNAB bundle MUST be executable without extra files. Thus, extensions MAY incorporate other files.
+
+It is beyond the scope of the specification to determine how those files are to be transmitted, stored, or retrieved.
 
 
 Next section: [The invocation image definition](102-invocation-image.md)

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -502,4 +502,45 @@ The built-in actions (`install`, `upgrade`, `uninstall`) MUST NOT appear in the 
 
 Implementations that do not support custom actions MUST NOT emit errors (either runtime or validation) if a bundle defines custom actions. That is, even if an implementation cannot execute custom actions, it MUST NOT fail to operate on bundles that declare custom actions.
 
+## Extensions
+
+In many cases, the bundle descriptor is a sufficient artifact for delivering a CNAB bundle, since invocation images and other images may be retrieved from registries and repositories. Consequently, it is important to provide an extension mechanism. An _extension_ is a named collection of auxiliary data whose meaning is defined outside of this specification.
+
+Tools _may_ define and declare additional fields inside of the `extension` section. Tools _must not_ define additional fields anywhere else in the bundle descriptor. Implementations _may_ produce an error or _may_ ignore additional fields outside of the extension. However, implementations _should_ preserve the data inside of the `extensions` section even when that information is not understood by the implementation.
+
+The `extensions` 
+
+```json
+{
+    "extensions": {
+        "example.com/duffle-bag": {
+            "icon": "https://example.com/icon.png",
+            "iconType": "PNG"
+        },
+        "example.com/backup-preferences": {
+            "frequency": "daily"
+        }
+    }
+}
+```
+
+The format is:
+
+```json
+{
+    "extensions": {
+        "EXTENSION NAME": "ARBITRARY JSON DATA"
+    }
+}
+```
+
+The fields are defined as follows:
+
+- `extensions` defines the wrapper object for extensions
+  - EXTENSION NAME: a unique name for an extension. Names _should_ follow the format `DOMAIN/PATH`, where DOMAIN conforms to the DNS naming convention, and path elements are separated by forward slashes (`/`).
+  - The value of the extension must be valid JSON, but is otherwise undefined.
+
+The usage of extensions is undefined. However, bundles _should_ be installable by runtimes that do not understand the extensions.
+
+
 Next section: [The invocation image definition](102-invocation-image.md)

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -31,12 +31,15 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
     "hostkey": {
       "env": "HOST_KEY",
       "path": "/etc/hostkey.txt"
+    }
+  },
+  "custom": {
+    "com.example.backup-preferences": {
+      "frequency": "daily"
     },
-    "image_token": {
-      "env": "AZ_IMAGE_TOKEN"
-    },
-    "kubeconfig": {
-      "path": "/home/.kube/config"
+    "com.example.duffle-bag": {
+      "icon": "https://example.com/icon.png",
+      "iconType": "PNG"
     }
   },
   "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
@@ -91,7 +94,7 @@ Source: [101.01-bundle.json](examples/101.01-bundle.json)
 The canonical JSON version of the above is:
 
 ```json
-{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"},"image_token":{"env":"AZ_IMAGE_TOKEN"},"kubeconfig":{"path":"/home/.kube/config"}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"description":"my microservice","digest":"sha256:aaaaaaaaaaaa...","image":"technosophos/microservice:1.2.3","refs":[{"field":"image.1.field","path":"image1path"}]}},"invocationImages":[{"digest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","parameters":{"backend_port":{"defaultValue":80,"destination":{"env":"BACKEND_PORT"},"maxValue":10240,"metadata":{"description":"The port that the back-end will listen on"},"minValue":10,"type":"int"}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
+{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"description":"my microservice","digest":"sha256:aaaaaaaaaaaa...","image":"technosophos/microservice:1.2.3","refs":[{"field":"image.1.field","path":"image1path"}]}},"invocationImages":[{"digest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","parameters":{"backend_port":{"defaultValue":80,"destination":{"env":"BACKEND_PORT"},"maxValue":10240,"metadata":{"description":"The port that the back-end will listen on"},"minValue":10,"type":"int"}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
 ```
 
 And here is how a "thick" bundle looks. Notice how the `invocationImage` and `images` fields reference the underlying docker image manifest (`application/vnd.docker.distribution.manifest.v2+json`), which in turn references the underlying images:
@@ -159,6 +162,24 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
 Source: [101.02-bundle.json](examples/101.02-bundle.json)
 
 In descriptions below, fields marked REQUIRED MUST be present in any conformant bundle descriptor, while fields not thusly marked are considered optional.
+
+## Dotted Names
+
+Within this specification, certain user-supplied names SHOULD be expressed in the form of a _dotted name_, which is defined herein as a name composed by concatenating name components (Unicode letters and the dash (`-`) character) together, separated by dot (`.`) characters. Whitespace characters are not allowed within names, nor is there a defined escape sequence for the `.` character.
+
+Dotted names are used to encourage name spacing and reduce the likelihood of naming collisions.
+
+Dotted names SHOULD follow the reverse-DNS pattern used by [Java, C#, and other languages](https://en.wikipedia.org/wiki/Reverse_domain_name_notation).
+
+CNAB tools MUST NOT treat these strings as domain names or domain components, as this specification allows characters that are not legal in DNS addresses.
+
+Examples:
+
+- `com.example.myapp.port`
+- `org.example.action.status`
+- `example.foo` (This format MAY be used, but the reverse DNS format is preferred)
+
+A string MUST have at least one dot to be considered a _dotted name_.
 
 ## Schema Version
 
@@ -481,7 +502,7 @@ Implementations MAY support user-defined additional actions as well. Such action
 }
 ```
 
-The action _name_ SHOULD be namespaced and SHOULD use reverse DNS notation - e.g. `com.example.action`. 
+The action _name_ SHOULD use _dotted name_ syntax as defined earlier in this section.
 
 The above declares three actions: `io.cnab.status`, `io.cnab.migrate` and `io.cnab.dry-run`. This means that the associated invocation images can handle requests for `io.cnab.status`, `io.cnab.migrate` and `io.cnab.dry-run` in addition to `install`, `upgrade`, and `uninstall`.
 
@@ -504,9 +525,9 @@ Implementations that do not support custom actions MUST NOT emit errors (either 
 
 ## Custom Extensions
 
-In many cases, the bundle descriptor is a sufficient artifact for delivering a CNAB bundle, since invocation images and other images may be retrieved from registries and repositories. Consequently, it is important to provide an extension mechanism. A _custom extension_ is a named collection of auxiliary data whose meaning is defined outside of this specification.
+In many cases, the bundle descriptor is a sufficient artifact for delivering a CNAB bundle, since invocation images and other images may be retrieved from registries and repositories. However, it is important to provide an extension mechanism. A _custom extension_ is a named collection of auxiliary data whose meaning is defined outside of this specification.
 
-Tools MAY define and declare additional fields inside of the `custom` section. Tools MUST NOT define additional fields anywhere else in the bundle descriptor. Implementations may produce an error or may ignore additional fields outside of the extension. However, implementations SHOULD preserve the data inside of the `custom` section even when that information is not understood by the implementation.
+Tools MAY define and declare additional fields inside of the `custom` section. Tools MUST NOT define additional fields anywhere else in the bundle descriptor. Implementations MAY produce an error or MAY ignore additional fields outside of the extension, but MUST be consistent in either ignoring or producing an error. However, implementations SHOULD preserve the data inside of the `custom` section even when that information is not understood by the implementation.
 
 The `custom` object is used as follows:
 
@@ -528,7 +549,7 @@ The format is:
 
 ```json
 {
-    "extensions": {
+    "custom": {
         "EXTENSION NAME": "ARBITRARY JSON DATA"
     }
 }
@@ -536,8 +557,8 @@ The format is:
 
 The fields are defined as follows:
 
-- `extensions` defines the wrapper object for extensions
-  - EXTENSION NAME: a unique name for an extension. Names SHOULD follow the reverse DNS format `DOMAIN.ADDITIONAL.INFORMATION`, where DOMAIN conforms to the reverse DNS naming convention (`com.example` or `io.cnab`), and additional elements are separated by dots (`.`).
+- `custom` defines the wrapper object for extensions
+  - EXTENSION NAME: a unique name for an extension. Names SHOULD follow the dotted name format described earlier in this section.
   - The value of the extension must be valid JSON, but is otherwise undefined.
 
 The usage of extensions is undefined. However, bundles SHOULD be installable by runtimes that do not understand the extensions.

--- a/901-process.md
+++ b/901-process.md
@@ -6,7 +6,7 @@ While CNAB has not officially been assigned to a standards body, it is good prac
 
 Specifications shall each track their own versions. A specification will call out a target version (such as 1.0), and then also include its phase (such as Working Draft, see below) to indicate progress towards the target version.
 
-The CNAB Core specification shall therefore be formally referenced as _Cloud Native Application Bundle Core 1.0.0_. The phase of the process _may_ be appended as a stability marker: _Cloud Native Application Bundle Core 1.0.0-WD_. It _may_ be abbreviated to _CNAB1_.
+The CNAB Core specification shall therefore be formally referenced as _Cloud Native Application Bundle Core 1.0.0_. The phase of the process MAY be appended as a stability marker: _Cloud Native Application Bundle Core 1.0.0-WD_. It MAY be abbreviated to _CNAB1_.
 
 ## Process
 

--- a/examples/101.01-bundle.json
+++ b/examples/101.01-bundle.json
@@ -3,50 +3,60 @@
     "hostkey": {
       "env": "HOST_KEY",
       "path": "/etc/hostkey.txt"
+    }
+  },
+  "custom": {
+    "com.example.backup-preferences": {
+      "frequency": "daily"
     },
-    "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
-    "images": {
-      "my-microservice": {
-        "description": "my microservice",
-        "digest": "sha256:aaaaaaaaaaaa...",
-        "image": "technosophos/microservice:1.2.3",
-        "refs": [
-          {
-            "field": "image.1.field",
-            "path": "image1path"
-          }
-        ]
-      }
-    },
-    "invocationImages": [
-      {
-        "digest": "sha256:aaaaaaa...",
-        "image": "technosophos/helloworld:0.1.0",
-        "imageType": "docker"
-      }
-    ],
-    "maintainers": [
-      {
-        "email": "matt.butcher@microsoft.com",
-        "name": "Matt Butcher",
-        "url": "https://example.com"
-      }
-    ],
-    "name": "helloworld",
-    "parameters": {
-      "backend_port": {
-        "defaultValue": 80,
-        "destination": {
-          "env": "BACKEND_PORT"
-        },
-        "maxValue": 10240,
-        "metadata": {
-          "description": "The port that the back-end will listen on"
-        },
-        "minValue": 10,
-        "type": "int"
-      }
-    },
-    "schemaVersion": "v1.0.0-WD",
-    "version": "0.1.2"
-  }
+    "com.example.duffle-bag": {
+      "icon": "https://example.com/icon.png",
+      "iconType": "PNG"
+    }
+  },
+  "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
+  "images": {
+    "my-microservice": {
+      "description": "my microservice",
+      "digest": "sha256:aaaaaaaaaaaa...",
+      "image": "technosophos/microservice:1.2.3",
+      "refs": [
+        {
+          "field": "image.1.field",
+          "path": "image1path"
+        }
+      ]
+    }
+  },
+  "invocationImages": [
+    {
+      "digest": "sha256:aaaaaaa...",
+      "image": "technosophos/helloworld:0.1.0",
+      "imageType": "docker"
+    }
+  ],
+  "maintainers": [
+    {
+      "email": "matt.butcher@microsoft.com",
+      "name": "Matt Butcher",
+      "url": "https://example.com"
+    }
+  ],
+  "name": "helloworld",
+  "parameters": {
+    "backend_port": {
+      "defaultValue": 80,
+      "destination": {
+        "env": "BACKEND_PORT"
+      },
+      "maxValue": 10240,
+      "metadata": {
+        "description": "The port that the back-end will listen on"
+      },
+      "minValue": 10,
+      "type": "int"
+    }
+  },
+  "schemaVersion": "v1.0.0-WD",
+  "version": "0.1.2"
+}

--- a/examples/101.01-bundle.json
+++ b/examples/101.01-bundle.json
@@ -1,15 +1,8 @@
 {
-    "credentials": {
-      "hostkey": {
-        "env": "HOST_KEY",
-        "path": "/etc/hostkey.txt"
-      },
-      "image_token": {
-        "env": "AZ_IMAGE_TOKEN"
-      },
-      "kubeconfig": {
-        "path": "/home/.kube/config"
-      }
+  "credentials": {
+    "hostkey": {
+      "env": "HOST_KEY",
+      "path": "/etc/hostkey.txt"
     },
     "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
     "images": {

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -99,8 +99,8 @@
                 }
             }
         },
-        "extensions":{
-            "$comment": "reserved for future usage"
+        "custom":{
+            "$comment": "reserved for custom extensions"
         },
         "parameters":{
             "description": "Parameters that can be injected into the invocation image",


### PR DESCRIPTION
This PR supersedes #28 

This adds a `custom` key as a designated place where extensions may be inserted into the `bundle.json` file.

See #28 for relevant discussion.