### PR TITLE
fix: remove CNAB_P_* support

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -341,17 +341,10 @@ Parameter names (the keys in `parameters`) ought to conform to the [Open Group B
 
 ### Resolving Destinations
 
-When resolving destinations, there are three ways a particular parameter value MAY be placed into the invocation image. Here is an example illustrating all three:
+When resolving destinations, there are two ways a particular parameter value MAY be placed into the invocation image. Here is an example illustrating both:
 
 ```json
 "parameters": {
-    "port": {
-        "defaultValue": 8080,
-        "type": "int",
-        "metadata": {
-            "description": "this will be $CNAB_P_PORT"
-        }
-    },
     "greeting": {
         "defaultValue": "hello",
         "type": "string",
@@ -375,13 +368,7 @@ When resolving destinations, there are three ways a particular parameter value M
 }
 ```
 
-The first parameter is `port`. This parameter has no destination field. Consequently, it's value will be injected into an environment variable whose prefix is `CNAB_P_`, with a capitalized version of the name (`PORT`) appended.
-
-```
-CNAB_P_PORT=8080
-```
-
-If the `destination` field is set, at least one of `env` or `path` MUST be specified. (Both MAY be provided).
+For the (REQUIRED) `destination` field, at least one of `env` or `path` MUST be specified. (Both MAY be provided).
 
 If `env` is set, the value of the parameter will be assigned to the given environment variable name. In the example in the previous section, `GREETING` is set to `hello`.
 

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -110,6 +110,7 @@ By default (if no override value is provided by the CNAB runtime), the above wil
 The parameter value is evaluated thus:
 
 - If the CNAB runtime provides a value, that value MAY be sanitized, then validated (as described below), then injected as the parameter value. In the event that sanitization or validation fail, the runtime SHOULD return an error and discontinue the action.
+- If the parameter is marked `required` and a value is not supplied, the CNAB Runtime MUST produce an error and discontinue action.
 - If the CNAB runtime does not provide a value, but `defaultValue` is set, then the default value MUST be used.
 - If no value is provided and `defaultValue` is unset, the runtime MUST set the value to an empty string (""), regardless of type.
 

--- a/104-claims.md
+++ b/104-claims.md
@@ -145,9 +145,7 @@ into the invocation container at runtime:
 
 > Credential data, which is also injected into the invocation image, is _not_ managed by the claim system. Rules for injecting credentials are found in [the bundle runtime definition](103-bundle-runtime.md).
 
-The parameters passed in by the user are vetted against `parameters.json` outside of the container, and then injected into the container as environment variables of the form: `$CNAB_P_{parameterName.toUpper}="{parameterValue}"`.
-
-For example, the parameter `hello_world` in the claim is presented to the invocation image as the environment variables `CNAB_P_HELLO_WORLD`.
+Parameters that are declared with an `env` key in the `destination` object, their values will be injected as environment variables according to the name specified. Likewise, files will be injected if `path` is set on `destination`.
 
 ## Calculating the Result
 
@@ -188,8 +186,8 @@ If both commands exit with code `0`, then the resulting claim will look like thi
 
 Tools that implement claims MAY then present `result` info to end users to show the result of running an invocation image.
 
-## TODO
+## Credentials and Claims
 
-- Define how action is determined, as this is beyond merely running an executable
+Credential data MUST NOT be stored in claims. Credentials are identity-specific, while claims are identity-neutral.
 
 Next section: [signing and verifying bundles](105-signing.md)


### PR DESCRIPTION
This removes the autogeneration of CNAB_P_* environment variables, and requires the `destination` field on parameters.

Additionally, this change provides a little more clarification on how `path` is to be handled in `destination`.

Closes #105