### PR TITLE
fix: add inline doc string on validate.sh

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+###
+# Use this to validate that the files in examples/* accord with the schema in schema/
+#
+# To get `ajv`, run `npm install -g ajv-cli`
+###
 
 set -eou pipefail
 


### PR DESCRIPTION
I just added a small doc string at the top of the validate script so that others would know how to run it.