### PR TITLE
docs: Move claims to separate specification

### DIFF
--- a/000-index.md
+++ b/000-index.md
@@ -4,15 +4,14 @@
     - [The bundle.json File](101-bundle-json.md)
     - [The Invocation Image Format](102-invocation-image.md)
     - [The Bundle Runtime](103-bundle-runtime.md)
-    - [The Claims System](104-claims.md)
-    - [Signing and Provenance](105-signing.md)
 2. [Cloud Native Application Bundle Registry 1.0.0 (CNAB-Reg)](200-cnab-registries.md)
 3. [Cloud Native Application Bundle Security 1.0.0 (CNAB-Sec)](300-cnab-security.md)
-4. Non-normative Sections
+4. [Cloud Native Application Bundle Claims 1.0.0 (CNAB-Claims1)](400-claims.md)
+5. Non-normative Sections
     - [Declarative Bundles](801-declarative-images.md)
     - [Credential Sets](802-credential-sets.md)
     - [Base Bundles](803-base-bundles.md)
     - [Repositories](804-repositories.md)
     - [Well known custom actions](805-well-known-custom-actions.md)
-5. Process Documentation
+6. Process Documentation
     - [Specification Process](901-process.md)

--- a/100-CNAB.md
+++ b/100-CNAB.md
@@ -55,12 +55,6 @@ Invocation images allow limited configuration, as defined in two places in the b
 - A bundle definition MAY declare zero or more configurable parameters. User-supplied parameters are injected into the invocation image. Parameters MAY be stored.
 - A bundle definition MAY declare zero or more credential requirements. This indicates which credentials MUST be passed into the invocation image in order for the invocation image to correctly authenticate to the services used by the bundle. Credentials are injected into the invocation image, but they MUST NOT be stored.
 
-Additionally, this document defines two auxiliary components of the CNAB system: claims and repositories.
-
-A _claim_ is a record of an installation of a bundle. When a bundle is installed into a host environment, it MAY be useful to track that bundle's history. The claims system is an OPTIONAL part of the specification which describes a standard format for storing bundle processing history.
-
-Bundles are stored in _bundle repositories_. A bundle repository is a network-accessible service for uploading and distributing CNAB objects.
-
 ### Key Terms
 
 - Application: The functional unit composed by the components described in a bundle. This MAY be comprised of a mixture of containers, VMs, IaaS and PaaS definitions, and other services, as well as instructions for orchestrators and service frameworks.
@@ -68,7 +62,6 @@ Bundles are stored in _bundle repositories_. A bundle repository is a network-ac
 - Bundle definition: The information about a bundle, its parameters, credentials, images, and usage
 - `bundle.json`: The unsigned JSON-encoded representation of a bundle definition.
 - `bundle.cnab`: The signed JSON-encoded representation of a bundle definition.
-- Claim: A record of a particular installation of a bundle.
 - Image: Used generically, a container image (e.g. OCI images) or a VM image.
 - Invocation Image: The image that contains the bootstrapping and installation logic for the bundle
 - Registry: A storage and retrieval service for CNAB objects.
@@ -90,15 +83,6 @@ The following subsections define the components of CNAB:
 - [The bundle.json File](101-bundle-json.md)
 - [The Invocation Image Format](102-invocation-image.md)
 - [The Bundle Runtime](103-bundle-runtime.md)
-- [The Claims System](104-claims.md)
-- [Signing and Provenance](105-signing.md)
-
-The following sections contain non-normative guidance
-
-- [Declarative Bundles](801-declarative-images.md)
-- [Credential Sets](802-credential-sets.md)
-- [Base Bundles](803-base-bundles.md)
-- [Storing CNAB Bundles](804-repositories.md)
 
 The process for standardization is described in an appendix:
 
@@ -111,7 +95,8 @@ The process for standardization is described in an appendix:
 - The initial draft of the spec included a `manifest.json`, a `ui.json` and a `parameters.json`. The `bundle.json` is now the only metadata file, containing what was formerly spread across those three.
 - The top-level `/cnab` directory was added to the bundle format due to conflicts with file hierarchy.
 - The signal handling method was discarded after early research showed its limitations. The replacement uses environment variables to trigger actions.
-- The credential set and claims concepts were introduced to cover areas upon which the original spec was silent.
-- The generic action `run` has been replaced by specific actions: `install`, `uninstall`, `upgrade`, `status`.
+- The generic action `run` has been replaced by specific actions: `install`, `uninstall`, `upgrade`.
+- The `status` action has been removed.
+- Registries, security, and claims have all be moved to separate specifications.
 
 Next section: [The bundle.json definition](101-bundle-json.md)

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -45,7 +45,7 @@ The _action_ is the action name. It MUST be either one of the built-in actions o
 
 A `CNAB_REVISION` SHOULD be passed into an install operation, and MUST be passed into `upgrade` and `uninstall`, where this is a _unique string_ indicating the current "version" of the _installation_. For example, if the `my_installation` installation is upgraded twice (changing only the parameters), three `CNAB_REVISIONS` should be generated (1. install, 2. upgrade, 3. upgrade).
 
-Revisions are regenerated on destructive operations so that one installation may be tracked over various revisions. CNAB Runtimes MUST generate a new `CNAB_REVISION` for every `install`, `upgrade`, or `uninstall` action. That is, if an application is installed once, upgraded twice, and then uninstalled, four revisions should have been generated. For additionally defined targets, a new `CNAB_REVISION` MUST be generated if the target is labeled `"modifies": true`, and MUST NOT be generated if `"modifies": false`.
+Revisions are regenerated on destructive operations so that one installation may be tracked over various revisions. CNAB Runtimes MUST generate a new `CNAB_REVISION` for every `install`, `upgrade`, or `uninstall` action. That is, if an application is installed once, upgraded twice, and then uninstalled, four revisions must be generated. For additionally defined targets, a new `CNAB_REVISION` MUST be generated if the target is labeled `"modifies": true`, and MUST NOT be generated if `"modifies": false`.
 
 A `CNAB_REVISION` SHOULD be a [ULID](https://github.com/ulid/spec).
 

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -35,13 +35,23 @@ CNAB_BUNDLE_NAME=helloworld
 CNAB_ACTION=install
 ```
 
-The _installation name_ is the name of the _instance of_ this application. Consider the situation where an application ("wordpress") is installed multiple times into the same cloud. Each installation MUST have a unique installation name, even though they will be installing the same CNAB bundle. Instance names MUST consist of Graph Unicode characters and MAY be user-readable. The Unicode Graphic characters include letters, marks, numbers, punctuation, symbols, and spaces, from categories L, M, N, P, S, Zs.
+The _installation name_ is the name of the _instance of_ this application. The value of `CNAB_INSTALLATION_NAME` MUST be the installation name. Consider the situation where an application ("wordpress") is installed multiple times into the same cloud. Each installation MUST have a unique installation name, even though they will be installing the same CNAB bundle. Instance names MUST consist of Graph Unicode characters and MAY be user-readable. The Unicode Graphic characters include letters, marks, numbers, punctuation, symbols, and spaces, from categories L, M, N, P, S, Zs.
 
-The _bundle name_ is the name of the bundle (as represented in `bundle.json`'s `name` field). The specification of this field is in the [bundle definition](101-bundle-json.md).
+The _bundle name_ is the name of the bundle (as represented in `bundle.json`'s `name` field). The specification of this field is in the [bundle definition](101-bundle-json.md). The value of `CNAB_BUNDLE_NAME` MUST be set to the bundle name.
 
-The _action_ is one of the action verbs defined in the section below.
+The _action_ is the action name. It MUST be either one of the built-in actions or one of the actions named in the `actions` portion of the bundle descriptor. `CNAB_ACTION` MUST be set to the action name.
 
-Optionally, `CNAB_REVISION` MAY be passed, where this is a _unique string_ indicating the current "version" of the _installation_. For example, if the `my_installation` installation is upgraded twice (changing only the parameters), three `CNAB_REVISIONS` should be generated (1. install, 2. upgrade, 3. upgrade). See [the Claims definition](104-claims.md) for details on revision ids. That `status` action MUST NOT increment the revision.
+### The CNAB Revision Variable
+
+A `CNAB_REVISION` SHOULD be passed into an install operation, and MUST be passed into `upgrade` and `uninstall`, where this is a _unique string_ indicating the current "version" of the _installation_. For example, if the `my_installation` installation is upgraded twice (changing only the parameters), three `CNAB_REVISIONS` should be generated (1. install, 2. upgrade, 3. upgrade).
+
+Revisions are regenerated on destructive operations so that one installation may be tracked over various revisions. CNAB Runtimes MUST generate a new `CNAB_REVISION` for every `install`, `upgrade`, or `uninstall` action. That is, if an application is installed once, upgraded twice, and then uninstalled, four revisions should have been generated. For additionally defined targets, a new `CNAB_REVISION` MUST be generated if the target is labeled `"modifies": true`, and MUST NOT be generated if `"modifies": false`.
+
+A `CNAB_REVISION` SHOULD be a [ULID](https://github.com/ulid/spec).
+
+A `CNAB_LAST_REVISION` SHOULD be provided during `upgrade` and `uninstall` operations. It MAY be provided during actions specified in the bundle descriptor. When provided, it MUST be set to the revision from the previous operation. If no previous revision exist, this SHOULD be set to the empty string (`""`). (It SHOULD NOT be set to `0`, as is sometimes the practice in UNIX programming, as `0` is considered a possible, though undesirable, revision ID)
+
+### Parameters as Variables
 
 As specified in the `bundle.json`, some parameters MAY be injected into the environment as environment variables.
 
@@ -243,5 +253,3 @@ The `/cnab/app/image-map.json` file mounted in the invocation image will be:
 ```
 
 The run tool MAY use this file to modify its behavior, if declarative substitution is not enough.
-
-Next Section: [The claims definition](104-claims.md)

--- a/400-claims.md
+++ b/400-claims.md
@@ -45,7 +45,7 @@ This is done so that implementors can standardize on a way of relating a release
 
 ### Anatomy of a Claim
 
-While implementors are not REQUIRED to implement claims, this is that standard format for claims-supporting systems.
+While implementors are not REQUIRED to implement claims, this is the standard format for claims-supporting systems.
 
 The CNAB claim is defined as a JSON document. The specification currently does not require that claims be formatted as Canonical JSON.
 
@@ -85,13 +85,7 @@ The CNAB claim is defined as a JSON document. The specification currently does n
 - updated: A timestamp indicating the last time this release claim was modified
 - result: The outcome of the bundle's last action (e.g. if action is install, this indicates the outcome of the installation.). It is an object with the following fields:
   - message: A human-readable string that communicates the outcome. Error messages MAY be included in `failure` conditions.
-  - action: Indicates the action that the current bundle is in. Valid actions are:
-    - install
-    - upgrade
-    - delete
-    - downgrade
-    - status
-    - unknown
+  - action: Indicates the action that the current bundle is in. This may be any of the built-in actions (`install`, `upgrade`, `uninstall`) as well as any custom actions as defined in the bundle descriptor. The special name `unknown` MAY be used in the case where the CNAB Runtime cannot determine the action name of a claim.
   - status: Indicates the status of the last phase transition. Valid statuses are:
     - success: completed successfully
     - failure: failed before completion
@@ -139,7 +133,7 @@ To satisfy these requirements, implementations of a CNAB package manager are exp
 
 ## Injecting Claim Data into an Invocation Image
 
-Complaint CNAB implementations MUST conform to this section.
+Compliant CNAB implementations MUST conform to this section.
 
 The claim is produced outside of the CNAB package. The following claim data is injected
 into the invocation container at runtime:
@@ -151,7 +145,7 @@ into the invocation container at runtime:
 
 > Credential data, which is also injected into the invocation image, is _not_ managed by the claim system. Rules for injecting credentials are found in [the bundle runtime definition](103-bundle-runtime.md).
 
-Parameters that are declared with an `env` key in the `destination` object, their values will be injected as environment variables according to the name specified. Likewise, files will be injected if `path` is set on `destination`.
+Parameters declared with an `env` key in the `destination` object MUST have their values injected as environment variables according to the name specified. Likewise, files MUST be injected if `path` is set on `destination`.
 
 ## Calculating the Result
 

--- a/400-claims.md
+++ b/400-claims.md
@@ -1,0 +1,197 @@
+# CNAB Claims 1.0 (CNAB-Claims1)
+*[Working Draft](901-process.md), Feb. 2019*
+
+This specification describes the CNAB Claims system. This is not part of the [CNAB Core](100-CNAB.md) specification, but is a specification describing how records of CNAB installations may be formatted for storage. Implementations of CNAB Core can meet the CNAB Core specification without implementing this specification.
+
+A _claim_ (or _claim receipt_) is a record of a CNAB installation. This specification describes how the claim system works.
+
+The claims system is designed to satisfy the requirements of the [Bundle Runtime specification](103-bundle-runtime.md) regarding the tracking `CNAB_REVISION` and `CNAB_LAST_REVISION`. It also provides a description of how the state of a bundle installation may be represented.
+
+This specification uses the terminology defined in [the CNAB Core specification](100-CNAB.md).
+
+## Concepts of Package Management
+
+A _package_ is a discrete data chunk that can be moved from location to location, and can be unpacked and installed onto a system. Typically, a package contains an application or application description. All package managers provide some explicit definition of a package and a package format.
+
+When a package is installed, the contents of a package are extracted and placed into the appropriate spaces on the target system, thus becoming an _installation_ (or _instance_) of the package.
+
+There are three core feature categories of a package manager system:
+
+- It can _install_ packages (initially put something onto a system)
+- It can _query_ installations (to see what is installed)
+- It can _upgrade_ and _delete_ packages (in other words, it can perform additional mutations on an existing installation)
+
+Package managers provide a wealth of other features, but the above are standard across all package managers. (For example, most package managers also provide a way to query what packages are available for installation.)
+
+This specification explains how CNAB records are generated such that continuity can be established across applications. In other words, this describes how CNAB bundles can be treated analogously to traditional packages.
+
+## Managing State
+
+Fundamentally, package managers provide a state management layer to keep records of what was installed. For example, [homebrew](http://homebrew.sh), a popular macOS package manager, stores records for all installed software in `/usr/local/Cellar`. Helm, the package manager for Kubernetes, stores state records in Kubernetes ConfigMaps located in the system namespace. The Debian Apt system stores state in `/var/run`. In all of these cases, the stored state allows the package managing system to be able to answer (quickly) the question of whether a given package is installed.
+
+```console
+$ brew info cscope
+cscope: stable 15.8b (bottled)
+Tool for browsing source code
+https://cscope.sourceforge.io/
+/usr/local/Cellar/cscope/15.8b (10 files, 714.2KB) *
+  Poured from bottle on 2017-05-15 at 09:24:58
+From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/cscope.rb
+```
+
+The CNAB Claims specification does not define where or how records are stored, nor how these records MAY be used by CNAB tooling. However, this specification describes how a CNAB-based system MUST emit the record to an invocation image, and provides some guidance on maintaining integrity of the system.
+
+This is done so that implementors can standardize on a way of relating a release claim (the record of a release) to release operations like `install`, `upgrade`, or `uninstall`. This, in turn, is necessary if CNAB bundles are expected to be executable by different implementations.
+
+### Anatomy of a Claim
+
+While implementors are not REQUIRED to implement claims, this is that standard format for claims-supporting systems.
+
+The CNAB claim is defined as a JSON document. The specification currently does not require that claims be formatted as Canonical JSON.
+
+```json
+{
+    "name": "technosophos.hellohelm",
+    "revision": "01CP6XM0KVB9V1BQDZ9NK8VP29",
+    "created": "2018-08-30T20:39:55.549002887-06:00",
+    "modified": "2018-08-30T20:39:59.611068556-06:00",
+    "bundle": {
+      "schemaVersion": "v1.0.0-WD",
+      "name": "technosophos.hellohelm",
+      "version": "0.1.0",
+      "invocationImages": [
+        {
+          "imageType": "docker",
+          "image": "technosophos/demo2:0.2.0"
+        }
+      ],
+      "images": {},
+      "parameters": {},
+      "credentials": {}
+    },
+    "result": {
+      "message": "",
+      "action": "install",
+      "status": "success"
+    },
+    "parameters": {}
+  }
+```
+
+- name: The name of the _installation_. This can be automatically generated, though humans may need to interact with it. It MUST be unique within the installation environment, though that constraint MUST be imposed externally. Elsewhere, this field is referenced as the _installation name_.
+- revision: An [ULID](https://github.com/ulid/spec) that MUST change each time the release is modified.
+- bundle: The bundle, as defined in [the Bundle Definition](101-bundle-json.md)
+- created: A timestamp indicating when this release claim was first created. This MUST not be changed after initial creation.
+- updated: A timestamp indicating the last time this release claim was modified
+- result: The outcome of the bundle's last action (e.g. if action is install, this indicates the outcome of the installation.). It is an object with the following fields:
+  - message: A human-readable string that communicates the outcome. Error messages MAY be included in `failure` conditions.
+  - action: Indicates the action that the current bundle is in. Valid actions are:
+    - install
+    - upgrade
+    - delete
+    - downgrade
+    - status
+    - unknown
+  - status: Indicates the status of the last phase transition. Valid statuses are:
+    - success: completed successfully
+    - failure: failed before completion
+    - underway: in progress. This should only be used if the invocation container MUST exit before it can determine whether all operations are complete. Note that `underway` is a _long term status_ that indicates that the installation's final state cannot be determined by the system. For this reason, it should be avoided.
+    - unknown: the state is unknown. This is an error condition.
+- parameters: Key/value pairs that were passed in during the operation. These are stored so that the operation can be re-run. Some implementations MAY choose not to store these for security or portability reasons.
+
+> Note that credential data is _never_ stored in a claim. For this reason, a claim is not considered _trivially repeatable_. Credentials MUST be supplied on each action.
+
+Timestamps in JSON are defined in the [ECMAScript specification](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-date-time-string-format), which matches the [ISO-8601 Extended Format](https://www.iso.org/iso-8601-date-and-time-format.html).
+
+### ULIDs for Revisions
+
+ULIDs have two properties that are desirable:
+
+- High probability of [uniqueness](https://github.com/ulid/javascript)
+- Sortable by time. The first 48 bits contain a timestamp
+
+Compared to a monotonic increment, ULID has strong advantages when it cannot be assumed that only one actor will be acting upon the CNAB claim record. While other unique IDs are not meaningfully sortable, ULIDs are. Thus, even unordered claim storage records can be sorted.
+
+### Parameters
+
+The parameter data stored in a claim data is _the resolved key/value pairs_ that result from the following transformation:
+
+- The values supplied by the user are validated by the rules specified in the `bundle.json` file
+- The output of this operation is a set of key/value pairs in which:
+  - Valid user-supplied values are presented
+  - Default values are supplied for all parameters where `defaultValue` is provided and no user-supplied value overrides this
+
+### How is the Claim Used
+
+The claim is used to inform any CNAB tooling about how to address a particular installation. For example, given the claim record, a package manager that implements CNAB should be able to:
+
+- List the _names_ of the installations, given a _bundle name_
+- Given an installation's _name_, return the _bundle info_ that is installed under that name
+- Given an installation _name_ and a _bundle_, generate a _bundle info_.
+  - This is accompanied by running the `install` path in the bundle
+- Given an installation's _name_, replace the _bundle info_ with updated _bundle info_, and update the revision with a new ULID, and the modified timestamp with the current time. This is an upgrade operation.
+  - This is accompanied by running the `upgrade` path in the bundle
+- Given an installation's name, mark the claim as deleted.
+  - This is accompanied by running the `uninstall` path in the bundle
+  - XXX: Do we want to allow the implementing system to remove the claim from its database (e.g. helm delete --purge) or remain silent on this matter?
+
+To satisfy these requirements, implementations of a CNAB package manager are expected to be able to store and retrieve state information. However, note that nothing in the CNAB specification tells _how or where_ this state information is to be stored. It is _not a requirement_ to store that state information inside of the invocation image. (In fact, this is discouraged.)
+
+## Injecting Claim Data into an Invocation Image
+
+Complaint CNAB implementations MUST conform to this section.
+
+The claim is produced outside of the CNAB package. The following claim data is injected
+into the invocation container at runtime:
+
+- `$CNAB_INSTALLATION_NAME`: The value of `claim.name`.
+- `$CNAB_BUNDLE_NAME`: The name of the present bundle.
+- `$CNAB_ACTION`: The action to be performed (install, upgrade, ...)
+- `$CNAB_REVISION`: The ULID for the present release revision. (On upgrade, this is the _new_ revision)
+
+> Credential data, which is also injected into the invocation image, is _not_ managed by the claim system. Rules for injecting credentials are found in [the bundle runtime definition](103-bundle-runtime.md).
+
+Parameters that are declared with an `env` key in the `destination` object, their values will be injected as environment variables according to the name specified. Likewise, files will be injected if `path` is set on `destination`.
+
+## Calculating the Result
+
+The `result` object is populated by the result of the invocation image's action. For example, consider the case where an invocation image executes an installation action. The action is represented by the following shell script, and `$CNAB_INSTALLATION_NAME` is set to `my_first_install`:
+
+```bash
+#!/bin/bash
+
+set -eo pipefail
+
+helm install stable/wordpress -n $CNAB_INSTALLATION_NAME > /dev/null
+kubectl create pod $CNAB_INSTALLATION_NAME > /dev/null
+echo "yay!"
+```
+
+(Note that the above script redirects data to `/dev/null` just to make the example easier. A production CNAB bundle might choose to include more verbose output.)
+
+If both commands exit with code `0`, then the resulting claim will look like this:
+
+```json
+{
+    "name": "technosophos.my_first_install",
+    "revision": "01CN530TF9Q095VTRYP1M8797C",
+    "bundle": {
+        "uri": "hub.docker.com/technosophos/example_cnab",
+        "name": "technosophos.example_cnab",
+        "version": "0.1.0"
+    },
+    "created": "TIMESTAMP",
+    "modified": "TIMESTAMP",
+    "result": {
+        "message": "yay!",    // From STDOUT (echo)
+        "action": "install",  // Determined by the action
+        "status": "success"   // if exit code == 0, success, else failure
+    }
+}
+```
+
+Tools that implement claims MAY then present `result` info to end users to show the result of running an invocation image.
+
+## Credentials and Claims
+
+Credential data MUST NOT be stored in claims. Credentials are identity-specific, while claims are identity-neutral.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Cloud Native Application Bundles (CNAB) are a package format specification that 
   1. [The bundle.json File](101-bundle-json.md)
   1. [The Invocation Image Format](102-invocation-image.md)
   1. [The Bundle Runtime](103-bundle-runtime.md)
-  1. [The Claims System](104-claims.md)
   1. [Signing and Provenance](105-signing.md)
 - Chapter 2: [Cloud Native Application Bundle Registry 1.0.0 (CNAB-Reg)](200-cnab-registries.md)
 - Chapter 3: [Cloud Native Application Bundle Security 1.0.0 (CNAB-Sec)](300-cnab-security.md)
+- Chapter 4: [Cloud Native Application Bundle Claims 1.0.0 (CNAB-Claims1)](400-claims.md)
 - Chapter 8: Non-normative Content
   1. [Declarative Invocation Images](801-declarative-images.md)
   1. [Credential Sets](802-credential-sets.md)

--- a/examples/400.01-claim.json
+++ b/examples/400.01-claim.json
@@ -1,0 +1,26 @@
+{
+    "name": "technosophos.hellohelm",
+    "revision": "01CP6XM0KVB9V1BQDZ9NK8VP29",
+    "created": "2018-08-30T20:39:55.549002887-06:00",
+    "modified": "2018-08-30T20:39:59.611068556-06:00",
+    "bundle": {
+      "schemaVersion": "v1.0.0-WD",
+      "name": "technosophos.hellohelm",
+      "version": "0.1.0",
+      "invocationImages": [
+        {
+          "imageType": "docker",
+          "image": "technosophos/demo2:0.2.0"
+        }
+      ],
+      "images": {},
+      "parameters": {},
+      "credentials": {}
+    },
+    "result": {
+      "message": "",
+      "action": "install",
+      "status": "success"
+    },
+    "parameters": {}
+  }

--- a/schema/claim.schema.json
+++ b/schema/claim.schema.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://cnab.io/v1/claims.schema.json",
+    "title": "CNAB Claims json schema",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "the name of the installation"
+        },
+        "revision": {
+            "type": "string",
+            "description": "the revision ID (ideally a ULID)"
+        },
+        "created": {
+            "type": "string",
+            "description": "The date created, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard"
+        },
+        "modified": {
+            "type": "string",
+            "description": "The date last modified, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard"
+        },
+        "bundle":{
+            "description": "The bundle descriptor",
+            "$ref": "http://cnab.io/v1/bundle.schema.json"
+        },
+        "result": {
+            "description": "The result of the last action",
+            "$ref": "#/definitions/result"
+
+        },
+        "parameters": {
+            "type": "object",
+            "description": "key/value pairs of parameter name to parameter value."
+        },
+        "custom": {
+            "$comment": "reserved for custom extensions"
+        },
+        "additionalProperties": false
+    },
+    "required": ["name", "revision", "created", "modified", "bundle"],
+    "definitions": {       
+        "result": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "the last message from the invocation image or runtime"
+                },
+                "action": {
+                    "type": "string",
+                    "description": "the name of the action. One of the built-ins (install, uninstall, upgrade) or a custom action."
+                },
+                "status": {
+                    "type": "string",
+                    "descripton": "The status of the last action",
+                    "enum": ["success", "failure", "underay", "unknown"]
+                }
+            },
+            "required": ["action", "message", "status"]
+        }
+    }
+}

--- a/validate.sh
+++ b/validate.sh
@@ -7,9 +7,14 @@
 
 set -eou pipefail
 
-for json in $(ls -1 examples/*); do
-  for schema in $(ls -1 schema/*); do
-    echo "Testing json '$json' against schema '$schema'"
-    ajv test -s $schema -d $json --valid
-  done
+for json in $(ls -1 examples/*-bundle.json); do
+  schema="schema/bundle.schema.json"
+  echo "Testing json '$json' against schema '$schema'"
+  ajv test -s $schema -d $json --valid
+done
+
+for json in $(ls -1 examples/*-claim.json); do
+  schema="schema/claim.schema.json"
+  echo "Testing json '$json' against schema '$schema'"
+  ajv test -s $schema -d $json --valid -r schema/bundle.schema.json
 done

--- a/validate.sh
+++ b/validate.sh
@@ -7,12 +7,14 @@
 
 set -eou pipefail
 
+# Test all of the bundle files against the bundle schema
 for json in $(ls -1 examples/*-bundle.json); do
   schema="schema/bundle.schema.json"
   echo "Testing json '$json' against schema '$schema'"
   ajv test -s $schema -d $json --valid
 done
 
+# Test all of the claim files against the claim schema.
 for json in $(ls -1 examples/*-claim.json); do
   schema="schema/claim.schema.json"
   echo "Testing json '$json' against schema '$schema'"


### PR DESCRIPTION
This removes 104 and adds 400, with largely the same content. A few clarifications were made along the way in order to move all mention of claims from CNAB Core. Schema and example have been added.

Closes #84