### PR TITLE
fix: Update schema for status messages

### DIFF
--- a/examples/805.01-status.json
+++ b/examples/805.01-status.json
@@ -1,0 +1,10 @@
+{
+    "status": "Ready",
+    "message": "All systems go",
+    "components":{
+      "web": {
+        "status": "Ready",
+        "message": "Listening on port :8080"
+      }
+    }
+  }

--- a/schema/status.schema.json
+++ b/schema/status.schema.json
@@ -2,7 +2,24 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "http://cnab.io/v1/status.schema.json",
     "title": "CNAB Status json schema",
-    "$ref": "#/definitions/component",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "description": "string identifying the status of a component (Ready, Pending, Failed are well known values)"
+        },
+        "message": {
+            "type": "string",
+            "description": "details about the current status"
+        },
+        "components": {
+            "type":"object",
+            "additionalProperties": {
+                "$ref": "#/definitions/component"
+            }	            
+        },
+        "additionalProperties": true
+    },
     "definitions": {
         "component":{
             "type":"object",
@@ -18,7 +35,7 @@
                 "components": {
                     "type":"object",
                     "additionalProperties": {
-                        "$ref": "#/definitions/component"
+                        "$ref": "#"
                     }	            
                 },
                 "additionalProperties": true

--- a/validate.sh
+++ b/validate.sh
@@ -20,3 +20,10 @@ for json in $(ls -1 examples/*-claim.json); do
   echo "Testing json '$json' against schema '$schema'"
   ajv test -s $schema -d $json --valid -r schema/bundle.schema.json
 done
+
+# Test all of the claim files against the claim schema.
+for json in $(ls -1 examples/*-status.json); do
+  schema="schema/status.schema.json"
+  echo "Testing json '$json' against schema '$schema'"
+  ajv test -s $schema -d $json --valid -r schema/bundle.schema.json
+done


### PR DESCRIPTION
This changes the status schema to work with the schema validators that we use. It's now less efficient, but it passes JSONSchema Validator and `ajv` now.

Closes #120