### PR TITLE
fix: remove redundant field in JSON schema

### DIFF
--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -327,10 +327,6 @@
                         "env":{
                             "description": "The environment variable name, such as MY_VALUE, in which the parameter value is stored",
                             "type": "string"
-                        },
-                        "description": {
-                            "description": "A user-friendly description of this parameter",
-                            "type": "string"
                         }
                     }
                 },


### PR DESCRIPTION
There were two description fields in the parameter definition. Only one is defined in the spec, so I removed the other.