### PR TITLE
Include original image names in image map

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -247,18 +247,21 @@ The following illustrates an `images` section:
 
 ```json
 {
-  "images": {
-    "backend": {
-      "description": "backend component image",
-      "digest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
-      "image": "example.com/gabrtv/vote-backend:a5ff67...",
-      "imageType": "docker"
-    },
-    "frontend": {
-      "description": "frontend component image",
-      "digest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
-      "image": "example.com/gabrtv/vote-frontend:a5ff67...",
-      "imageType": "docker"
+"images": {
+        "frontend": { 
+            "description": "frontend component image",
+            "imageType": "docker",
+            "image": "example.com/gabrtv/vote-frontend@sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
+            "originalImage": "example.com/opendeis/vote-frontend@sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
+            "digest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685"
+        },
+        "backend": {
+            "description": "backend component image",
+            "imageType": "docker",
+            "image": "example.com/gabrtv/vote-backend@sha256:bca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120686",
+            "originalImage": "example.com/opendeis/vote-backend@sha256:bca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120686",
+            "digest": "sha256:bca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120686"
+        }
     }
   }
 }
@@ -269,8 +272,10 @@ Fields:
 - `images`: The list of dependent images
   - `description`: The description field provides additional context of the purpose of the image.
   - `imageType`: The `imageType` field MUST describe the format of the image. The list of formats is open-ended, but any CNAB-compliant system MUST implement `docker` and `oci`. The default is `oci`.
-  - `image`: The REQUIRED `image` field provides a valid reference (REGISTRY/NAME:TAG) for the image. Note that SHOULD be a CAS SHA, not a version tag as in the example above.
-  - `digest`: MUST contain a digest, in [OCI format](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#digests), to be used to compute the integrity of the image. The calculation of how the image matches the digest is dependent upon image type. (OCI, for example, uses a Merkle tree while VM images are checksums.)
+  - `image`: The REQUIRED `image` field provides a valid reference for the image. Note that SHOULD be a CAS SHA, as in the example above, not a version tag.
+  - `originalImage`: provides a valid reference for the image. Note that SHOULD be a CAS SHA, as in the example above, not a version tag. If the `originalImage` field is omitted, its value defaults to that of the `image` field.
+  - `digest`: MUST contain a digest, in [OCI format](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#digests), to be used to compute the integrity of the image. The calculation of how the image matches the digest is dependent upon image type. (OCI, for example, uses a Merkle tree while VM images use checksums.)
+  - `originalDigest`: contains a digest, in [OCI format](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#digests), to be used to compute the integrity of the original image. The calculation of how the original image matches the digest is dependent upon image type. If the `originalDigest` field is omitted, as in the example above, its value defaults to that of the `digest` field.
   - `size`: The image size in bytes
   - `platform`: The target platform, as an object with two fields:
     - `architecture`: The architecture of the image (`i386`, `amd64`, `arm32`...)

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -275,7 +275,6 @@ Fields:
   - `image`: The REQUIRED `image` field provides a valid reference for the image. Note that SHOULD be a CAS SHA, as in the example above, not a version tag.
   - `originalImage`: provides a valid reference for the image. Note that SHOULD be a CAS SHA, as in the example above, not a version tag. If the `originalImage` field is omitted, its value defaults to that of the `image` field.
   - `digest`: MUST contain a digest, in [OCI format](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#digests), to be used to compute the integrity of the image. The calculation of how the image matches the digest is dependent upon image type. (OCI, for example, uses a Merkle tree while VM images use checksums.)
-  - `originalDigest`: contains a digest, in [OCI format](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#digests), to be used to compute the integrity of the original image. The calculation of how the original image matches the digest is dependent upon image type. If the `originalDigest` field is omitted, as in the example above, its value defaults to that of the `digest` field.
   - `size`: The image size in bytes
   - `platform`: The target platform, as an object with two fields:
     - `architecture`: The architecture of the image (`i386`, `amd64`, `arm32`...)

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -245,4 +245,4 @@ The `/cnab/app/image-map.json` file mounted in the invocation image will be:
 }
 ```
 
-The run tool MAY use this file to modify its behavior. For example, a run tool MAY replace default image references with the references provided in this file or MAY substitute image references having a value of an `originalImage` field of this file with the value of the corresponding `image` field of this file (in which case the run tool MAY also substitute corresponding digests having values in `originalDigest` fields with values of the corresponding `originalDigest` fields).
+The run tool MAY use this file to modify its behavior. For example, a run tool MAY replace default image references with the references provided in this file or MAY substitute image references having a value of an `originalImage` field of this file with the value of the corresponding `image` field of this file.

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -195,8 +195,9 @@ For this example CNAB bundle:
   "images": {
     "my-microservice": {
       "description": "my microservice",
-      "digest": "sha256:aaaaaaaaaaaa...",
-      "image": "technosophos/microservice:1.2.3"
+      "image": "technosophos/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
+      "originalImage": "gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
+      "digest": "sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687"
     }
   },
   "invocationImages": [
@@ -237,10 +238,11 @@ The `/cnab/app/image-map.json` file mounted in the invocation image will be:
 {
     "my-microservice": {
         "description": "my microservice",
-        "digest": "sha256:aaaaaaaaaaaa...",
-        "image": "technosophos/microservice:1.2.3"
+        "image": "technosophos/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
+        "originalImage": "gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
+        "digest": "sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687"
     }
 }
 ```
 
-The run tool MAY use this file to modify its behavior. For example, a run tool MAY replace default image references with the references provided in this file.
+The run tool MAY use this file to modify its behavior. For example, a run tool MAY replace default image references with the references provided in this file or MAY substitute image references having a value of an `originalImage` field of this file with the value of the corresponding `image` field of this file (in which case the run tool MAY also substitute corresponding digests having values in `originalDigest` fields with values of the corresponding `originalDigest` fields).

--- a/examples/103.1-bundle.json
+++ b/examples/103.1-bundle.json
@@ -15,8 +15,9 @@
   "images": {
     "my-microservice": {
       "description": "my microservice",
-      "digest": "sha256:aaaaaaaaaaaa...",
-      "image": "technosophos/microservice:1.2.3"
+      "image": "technosophos/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
+      "originalImage": "gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
+      "digest": "sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687"
     }
   },
   "invocationImages": [

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -172,6 +172,10 @@
                     "description": "A resolvable reference to the image. This may be interpreted differently based on imageType, but the default is to treat this as an OCI image",
                     "type": "string"
                 },
+                "originalImage":{
+                    "description": "A resolvable reference to the image. This may be interpreted differently based on imageType, but the default is to treat this as an OCI image. If this is not specified, the value is assumed to be that of the image field",
+                    "type": "string"
+                },
                 "imageType":{
                     "description": "The type of image. If this is not specified, 'oci' is assumed",
                     "type": "string",
@@ -179,6 +183,10 @@
                 },
                 "digest":{
                     "description": "A cryptographic hash digest that can be used to validate the image. This may be interpreted differently based on imageType",
+                    "type": "string"
+                },
+                "originalDigest":{
+                    "description": "A cryptographic hash digest that can be used to validate the image. This may be interpreted differently based on imageType. If this is not specified, the value is assumed to be that of the originalDigest field",
                     "type": "string"
                 },
                 "size": {

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -185,10 +185,6 @@
                     "description": "A cryptographic hash digest that can be used to validate the image. This may be interpreted differently based on imageType",
                     "type": "string"
                 },
-                "originalDigest":{
-                    "description": "A cryptographic hash digest that can be used to validate the image. This may be interpreted differently based on imageType. If this is not specified, the value is assumed to be that of the originalDigest field",
-                    "type": "string"
-                },
                 "size": {
                     "description": "The image size in bytes",
                     "type":"integer"


### PR DESCRIPTION
Provide a normative way of specifying the original image name so that
invocation images can map the original to the new image name.

Also tidy up the definition of the image field by using the recommended CAS
SHA form in examples and by deleting the misleading `REGISTRY/NAME:TAG`
syntax.

Fixes https://github.com/deislabs/cnab-spec/issues/134