### PR TITLE
Add `schema` field to parameters section

### DIFF
--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -108,8 +108,14 @@
             "additionalProperties": {
                 "$ref": "#/definitions/parameter"
             }
+        },
+        "schemas": {
+            "description": "A set of named JSON Schema documents.",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "http://json-schema.org/draft-07/schema#"
+            }
         }
-        
     },
     "required": [ "name", "version", "invocationImages", "schemaVersion"],
     "definitions": {
@@ -221,13 +227,17 @@
             }
         },
         "parameter": {
-            "description": "A paramter that can be passed into the invocation image",
+            "description": "A parameter that can be passed into the invocation image",
             "type": "object",
             "properties": {
                 "type": {
                     "description": "The data type of the parameter",
                     "type":"string",
                     "pattern":"^(string|int|integer|numeric|null|boolean|bytes)$"
+                },
+                "schema": {
+                    "description": "A reference to a JSON schema document that is used to validate the structure of the parameter. Only applies to string parameter types.",
+                    "type": "string"
                 },
                 "required": {
                     "description": "If true, this parameter must be supplied",


### PR DESCRIPTION
This PR allows bundle authors to specify additional parameter types (such as arrays and objects) through a new field: `schema`. The referenced schema document must conform to the JSON schema specification.

This PR is a follow up from the conversation started [in a proposal to introduce complex objects](https://github.com/deislabs/cnab-spec/issues/114#issuecomment-467182356) and addresses the first action item listed [here](https://github.com/deislabs/cnab-spec/issues/114#issuecomment-474096981). 

Instead of specifying `schema` as an inlined JSON Schema document, we decided to allow bundle authors to embed a schema document within the bundle. This is mainly because of the user experience issues described in this [slack thread](https://cloud-native.slack.com/archives/CEX1W7WMD/p1553011275226300).