### PR TITLE
add front matter for rendering a hugo website 

### DIFF
--- a/000-index.md
+++ b/000-index.md
@@ -1,5 +1,5 @@
 ---
-title: CNAB Specification
+title: Index
 weight: 001
 ---
 

--- a/000-index.md
+++ b/000-index.md
@@ -1,3 +1,8 @@
+---
+title: CNAB Specifications
+weight: 000
+---
+
 # CNAB Specifications
 
 1. [Cloud Native Application Bundle Core 1.0.0 (CNAB1)](100-CNAB.md)

--- a/000-index.md
+++ b/000-index.md
@@ -1,6 +1,6 @@
 ---
-title: CNAB Specifications
-weight: 000
+title: CNAB Specification
+weight: 001
 ---
 
 # CNAB Specifications

--- a/100-CNAB.md
+++ b/100-CNAB.md
@@ -1,5 +1,5 @@
 ---
-title: Core
+title: CNAB Core
 weight: 100
 ---
 

--- a/100-CNAB.md
+++ b/100-CNAB.md
@@ -1,3 +1,8 @@
+---
+title: Core
+weight: 100
+---
+
 # Cloud Native Application Bundle Core 1.0.0 (CNAB1)
 *[Working Draft](901-process.md), Nov. 2018*
 

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -1,3 +1,8 @@
+---
+title: The bundle.json File
+weight: 101
+---
+
 # The bundle.json File
 
 This section describes the format and function of the `bundle.json` document.

--- a/102-invocation-image.md
+++ b/102-invocation-image.md
@@ -1,3 +1,8 @@
+---
+title: The Invocation Images
+weight: 102
+---
+
 # The Invocation Images
 
 The `invocationImages` section of a `bundle.json` MUST contain at least one image (the invocation image). This image MUST be formatted according to the specification laid out in the present document.

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -1,3 +1,8 @@
+---
+title: The Bundle Runtime
+weight: 103
+---
+
 # The Bundle Runtime
 
 This section describes how the invocation image is executed, and how data is injected into the image.

--- a/104-bundle-formats.md
+++ b/104-bundle-formats.md
@@ -1,3 +1,8 @@
+---
+title: Bundle Formats
+weight: 104
+---
+
 # Bundle Formats
 
 This section of the specification addresses how bundles are to be represented. The CNAB Core specification defines two representations ("thick" and "thin"), and any CNAB compliant bundle MUST be representable in both formats. CNAB runtimes MUST support thin bundles, and SHOULD support thick bundles. Various other CNAB tools MAY support only one or the other. For example, a bundle builder could support generating thick bundles, but not thin bundles, and yet still meet the requirements of the specification.

--- a/200-CNAB-registries.md
+++ b/200-CNAB-registries.md
@@ -1,3 +1,8 @@
+---
+title: Registries
+weight: 200
+---
+
 # CNAB Registries 1.0
 Working Draft, Feb. 2019
 

--- a/300-CNAB-security.md
+++ b/300-CNAB-security.md
@@ -1,5 +1,5 @@
 ---
-title: Bundles Security
+title: Bundle Security
 weight: 300
 ---
 

--- a/300-CNAB-security.md
+++ b/300-CNAB-security.md
@@ -1,3 +1,8 @@
+---
+title: Bundles Security
+weight: 300
+---
+
 # Cloud Native Application Bundles Security (CNAB-Sec) 1.0 WD
 
 The CNAB Security specification augments the [CNAB Core specification](100-CNAB.md) by standardizing on security mechanisms for signing, verifying, and attesting CNAB packages. It describes both a client/registry security model and a verification chain (provenance) model. By design, this provides security mechanisms that work in air-gapped networks.

--- a/400-claims.md
+++ b/400-claims.md
@@ -1,3 +1,8 @@
+---
+title: CNAB Claims 1.0
+weight: 400
+---
+
 # CNAB Claims 1.0 (CNAB-Claims1)
 *[Working Draft](901-process.md), Feb. 2019*
 

--- a/400-claims.md
+++ b/400-claims.md
@@ -1,5 +1,5 @@
 ---
-title: CNAB Claims 1.0
+title: Claims System
 weight: 400
 ---
 

--- a/801-declarative-images.md
+++ b/801-declarative-images.md
@@ -1,3 +1,8 @@
+---
+title: Declarative Invocation Images
+weight: 801
+---
+
 # Declarative Invocation Images
 
 This section is non-normative. A CNAB implementation MAY implement this portion to be considered conforming. However, this section maps out what the authors consider a best practice.

--- a/802-credential-sets.md
+++ b/802-credential-sets.md
@@ -1,3 +1,8 @@
+---
+title: Credential Sets
+weight: 802
+---
+
 # Credential Sets
 
 This is a non-normative section that describes how credentials can be passed into an invocation image. This strategy is implemented by `duffle`.

--- a/803-base-bundles.md
+++ b/803-base-bundles.md
@@ -1,3 +1,8 @@
+---
+title: The Base Bundle Pattern
+weight: 803
+---
+
 # The Base Bundle Pattern
 
 This section of the specification is non-normative. It describes a pattern for using the contents of one bundle in another bundle as a form of extension or inheritance. While this is non-normative to the specification, facilitating this pattern was a goal of CNAB's design.

--- a/804-repositories.md
+++ b/804-repositories.md
@@ -1,6 +1,5 @@
 ---
-title: CNAB Registries
-weight: 804
+title: Registries
 ---
 
 # CNAB Registries

--- a/804-repositories.md
+++ b/804-repositories.md
@@ -1,3 +1,8 @@
+---
+title: CNAB Registries
+weight: 804
+---
+
 # CNAB Registries
 
 CNAB bundles can be stored in [OCI Distribution-compliant repository](https://github.com/opencontainers/distribution-spec/blob/master/spec.md)

--- a/805-well-known-custom-actions.md
+++ b/805-well-known-custom-actions.md
@@ -1,5 +1,6 @@
 ---
 title: Well known custom actions
+weight: 805
 ---
 
 # Well known custom actions

--- a/805-well-known-custom-actions.md
+++ b/805-well-known-custom-actions.md
@@ -1,6 +1,5 @@
 ---
 title: Well known custom actions
-weight: 805
 ---
 
 # Well known custom actions

--- a/805-well-known-custom-actions.md
+++ b/805-well-known-custom-actions.md
@@ -1,3 +1,8 @@
+---
+title: Well known custom actions
+weight: 805
+---
+
 # Well known custom actions
 
 This section is non-normative, but is here to propose a common set of optional actions a CNAB package MAY implement, and that CNAB tools can understand.

--- a/901-process.md
+++ b/901-process.md
@@ -1,3 +1,8 @@
+---
+title: Appendix A: Preliminary Release Process
+weight: 901
+---
+
 # Appendix A: Preliminary Release Process
 
 While CNAB has not officially been assigned to a standards body, it is good practice to put in place a provisional process for indicating the status, stability, and reliability of the specification.

--- a/901-process.md
+++ b/901-process.md
@@ -1,5 +1,5 @@
 ---
-title: Appendix A: Preliminary Release Process
+title: Standardization Process
 weight: 901
 ---
 


### PR DESCRIPTION
This PR adds a small bit of metadata to each page, in order to structure the markdown content for rendering as a website:

![https://user-images.githubusercontent.com/686194/54712611-f80e8200-4b09-11e9-9dcb-4ccef37556d6.png](https://user-images.githubusercontent.com/686194/54712611-f80e8200-4b09-11e9-9dcb-4ccef37556d6.png)



The site is a [work in progress](https://github.com/deislabs/cnab.io/pull/10) - [github.com/deislabs/cnab.io/pull/10](https://github.com/deislabs/cnab.io/pull/10)

It will fetch the contents of this repo and import it into cnab.io - rather than adding Hugo _config/theme/noise_ to this repo.