### PR TITLE
chore(brigade.js): update kashti build url

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -52,7 +52,7 @@ class Notification {
     this.payload = e.payload;
     this.name = name;
     this.externalID = e.buildID;
-    this.detailsURL = `https://azure.github.io/kashti/builds/${ e.buildID }`;
+    this.detailsURL = `https://brigadecore.github.io/kashti/builds/${ e.buildID }`;
     this.title = "running check";
     this.text = "";
     this.summary = "";


### PR DESCRIPTION
The public Kashti instance that displays recent Brigade CI builds for many projects, including this one, has changed.  It now lives at: https://brigadecore.github.io/kashti