### PR TITLE
Fixed broken links in Table of Contents (case sensitive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Cloud Native Application Bundles (CNAB) are a package format specification that 
   1. [The Invocation Image Format](102-invocation-image.md)
   1. [The Bundle Runtime](103-bundle-runtime.md)
   1. [Bundle Formats (Thick and Thin)](104-bundle-formats.md)
-- Chapter 2: [Cloud Native Application Bundle Registry 1.0.0 (CNAB-Reg)](200-cnab-registries.md)
-- Chapter 3: [Cloud Native Application Bundle Security 1.0.0 (CNAB-Sec)](300-cnab-security.md)
+- Chapter 2: [Cloud Native Application Bundle Registry 1.0.0 (CNAB-Reg)](200-CNAB-registries.md)
+- Chapter 3: [Cloud Native Application Bundle Security 1.0.0 (CNAB-Sec)](300-CNAB-security.md)
 - Chapter 4: [Cloud Native Application Bundle Claims 1.0.0 (CNAB-Claims1)](400-claims.md)
 - Chapter 8: Non-normative Content
   1. [Declarative Invocation Images](801-declarative-images.md)


### PR DESCRIPTION
Fixes broken links in Table of Contents section of README.md. Links are broken due to case sensitive URLs/File Names. 

closes #151