### PR TITLE
Converts parameters section to extend JSON Schema

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -72,16 +72,14 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
   "name": "helloworld",
   "parameters": {
     "backend_port": {
-      "defaultValue": 80,
+      "default": 80,
       "destination": {
         "env": "BACKEND_PORT"
       },
-      "maxValue": 10240,
-      "metadata": {
-        "description": "The port that the back-end will listen on"
-      },
-      "minValue": 10,
-      "type": "int"
+      "maximum": 10240,
+      "description": "The port that the back-end will listen on",
+      "minimum": 10,
+      "type": "integer"
     }
   },
   "schemaVersion": "v1.0.0-WD",
@@ -93,7 +91,7 @@ Source: [101.01-bundle.json](examples/101.01-bundle.json)
 The canonical JSON version of the above is:
 
 ```json
-{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"description":"my microservice","digest":"sha256:aaaaaaaaaaaa...","image":"technosophos/microservice:1.2.3"}},"invocationImages":[{"digest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","parameters":{"backend_port":{"defaultValue":80,"destination":{"env":"BACKEND_PORT"},"maxValue":10240,"metadata":{"description":"The port that the back-end will listen on"},"minValue":10,"type":"int"}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
+{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"description":"my microservice","digest":"sha256:aaaaaaaaaaaa...","image":"technosophos/microservice:1.2.3"}},"invocationImages":[{"digest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","parameters":{"backend_port":{"default":80,"destination":{"env":"BACKEND_PORT"},"maximum":10240,"description":"The port that the back-end will listen on","minimum":10,"type":"integer"}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
 ```
 
 And here is how a "thick" bundle looks. Notice how the `invocationImage` and `images` fields reference the underlying docker image manifest (`application/vnd.docker.distribution.manifest.v2+json`), which in turn references the underlying images:
@@ -142,16 +140,13 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
   "name": "helloworld",
   "parameters": {
     "backend_port": {
-      "defaultValue": 80,
+      "default": 80,
       "destination": {
         "path": "/path/to/backend_port"
       },
-      "maxValue": 10240,
-      "metadata": {
-        "description": "The port that the backend will listen on"
-      },
-      "minValue": 10,
-      "type": "int"
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
     }
   },
   "schemaVersion": "v1.0.0-WD",
@@ -189,7 +184,7 @@ The schema version must reference the version of the schema used for this docume
 - `WD` indicates that the document references a working draft of the specification, and is not considered stable.
 - `CR` indicates that the document references a candidate recommendation. Stability is not assured.
 
-The current schema version is `v1.0.0-WD`, which is considered unstable. 
+The current schema version is `v1.0.0-WD`, which is considered unstable.
 
 ## Name and Version: Identifying Metadata
 
@@ -252,27 +247,27 @@ The following illustrates an `images` section:
 
 ```json
 {
-"images": {
-        "frontend": { 
-            "description": "frontend component image",
-            "imageType": "docker",
-            "image": "example.com/gabrtv/vote-frontend:a5ff67...",
-            "digest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685"
-        },
-        "backend": {
-            "description": "backend component image",
-            "imageType": "docker",
-            "digest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
-            "image": "example.com/gabrtv/vote-backend:a5ff67..."
-        }
+  "images": {
+    "backend": {
+      "description": "backend component image",
+      "digest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
+      "image": "example.com/gabrtv/vote-backend:a5ff67...",
+      "imageType": "docker"
+    },
+    "frontend": {
+      "description": "frontend component image",
+      "digest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
+      "image": "example.com/gabrtv/vote-frontend:a5ff67...",
+      "imageType": "docker"
     }
+  }
 }
 ```
 
 Fields:
 
 - `images`: The list of dependent images
-  - `description`: The description field provides additional context of the purpose of the image. 
+  - `description`: The description field provides additional context of the purpose of the image.
   - `imageType`: The `imageType` field MUST describe the format of the image. The list of formats is open-ended, but any CNAB-compliant system MUST implement `docker` and `oci`. The default is `oci`.
   - `image`: The REQUIRED `image` field provides a valid reference (REGISTRY/NAME:TAG) for the image. Note that SHOULD be a CAS SHA, not a version tag as in the example above.
   - `digest`: MUST contain a digest, in [OCI format](https://github.com/opencontainers/image-spec/blob/master/descriptor.md#digests), to be used to compute the integrity of the image. The calculation of how the image matches the digest is dependent upon image type. (OCI, for example, uses a Merkle tree while VM images are checksums.)
@@ -288,47 +283,85 @@ The image map data is made available to the invocation image at runtime. This al
 
 The `parameters` section of the `bundle.json` defines which parameters a user (person installing a CNAB bundle) MAY configure on an invocation image. Parameters represent information about the application configuration, and may be persisted by the runtime.
 
-Parameter specifications are flat (not tree-like), consisting of name/value pairs. The name is fixed, but the value MAY be overridden by the user. The parameter definition includes a specification on how to constrain the values submitted by the user.
+Parameter specifications consist of name/value pairs. The name is fixed, but the value MAY be overridden by the user. The parameter definition includes a specification of how to constrain the values submitted by the user.
 
 ```json
-"parameters": {
-    "backend_port" : {
-        "type" : "int",
-        "defaultValue": 80,
-        "minValue": 10,
-        "maxValue": 10240,
-        "metadata": {
-            "description": "The port that the backend will listen on"
-        },
-        "destination": {
-            "env": "MY_ENV_VAR",
-            "path": "/my/destination/path"
-        },
-        "apply-to": ["install", "action1", "action2"]
+{
+  "parameters": {
+    "backend_port": {
+      "apply-to": [
+        "install",
+        "action1",
+        "action2"
+      ],
+      "default": 80,
+      "description": "The port that the backend will listen on",
+      "destination": {
+        "env": "MY_ENV_VAR",
+        "path": "/my/destination/path"
+      },
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
     }
+  }
 }
 ```
 
 - `parameters`: name/value pairs describing a user-overridable parameter
-  - `<name>`: The name of the parameter. This is REQUIRED. In the example above, this is `backend_port`. This
-    is mapped to a value definition, which contains the following fields:
-    - `type`: "null", "boolean", "string", "number", "integer", "bytes". These types correspond to the main primitive types of JSON (with _integer_ and _bytes_ as special cases). Objects and arrays are not supported, as the serialization of these is underdetermined. (REQUIRED)
-    - `required`: if this is set to true, a value MUST be specified (OPTIONAL, not shown)
-    - `defaultValue`: The default value. For type `bytes`, defaultValue is a string containing a base64 payload (OPTIONAL)
-    - `enum`: an array of allowed values. For type `bytes`, values must be strings containing a base64 payload (OPTIONAL)
-    - `minimum`: Minimum value (for numeric and integer) (OPTIONAL)
-    - `exclusiveMinimum`: Exclusive minimum value (for numeric and integer) (OPTIONAL) 
-    - `maximum`: Maximum value (for numeric and integer) (OPTIONAL)
-    - `exclusiveMaximum`: Exclusive maximum value (for numeric and integer) (OPTIONAL)
-    - `minLength`: Minimum number of characters allowed in the field (for strings and bytes) (OPTIONAL)
-    - `maxLength`: Maximum number of characters allowed in the field (for strings and bytes) (OPTIONAL)
-    - `pattern`: An ECMA 262 regular expression that must match the string (OPTIONAL)
-    - `metadata`: Holds fields that are not used in validation (OPTIONAL)
-      - `description`: A user-friendly description of the parameter
+  - `required`: A list of required parameters. MUST be an array of strings.(OPTIONAL)
+  - `<name>`: The name of the parameter. In the example above, this is `backend_port`. This
+    is mapped to a value definition, which contains the following fields (REQUIRED):
+    - `$comment`: Reserved for comments from bundle authors to readers or maintainers of the bundle. This MUST be a string (OPTIONAL)
+    - `$id`: A URI for the schema resolved against the base URI of its parent schema. MUST be a uri-reference string in accordance with [RFC3986](https://tools.ietf.org/html/rfc3986) (OPTIONAL)
+    - `$ref`: A URI reference used to resolve a schema located elsewhere. This MUST be a uri-reference string in accordance with [RFC3986](https://tools.ietf.org/html/rfc3986) (OPTIONAL)
+    - `additionalItems`: Parameter validation requiring that any additional items included in a user-provided array must conform to the specified schema. MUST be a JSON schema. (OPTIONAL)
+    - `additionalProperties`: Parameter validation requiring that any additional properties in the user-provided object conform to the specified schema. MUST be a JSON schema. (OPTIONAL)
+    - `allOf`: Parameter validation requiring that the user-provided value match ALL of the specified schemas. MUST be a non-empty array of JSON schemas. (OPTIONAL)
+    - `anyOf`: Parameter validation requiring that the user-provided value match ANY of the specified schemas. MUST be a non-empty array of JSON schemas. (OPTIONAL)
+    - `apply-to`: restricts this parameter to a given list of actions. If empty or missing, applies to all actions (OPTIONAL)
+    - `const`: Parameter validation requiring that the user-provided value matches exactly the specified const. MAY be of any type, including null. (OPTIONAL)
+    - `contains`: Parameter validation requiring at least one item included in the user-provided array conform to the specified schema. MUST be a JSON schema. (OPTIONAL)
+    - `contentEncoding`: Indicates that the user-provided content should interpreted as binary data and decoded using the encoding named by this property. MUST be a string in accordance with [RFC2045, Sec 6.1](https://json-schema.org/latest/json-schema-validation.html#RFC2045). (OPTIONAL)
+    - `contentMediaType`: MIME type indicating the media type of the user-provided content. MUST be a string in accordance with [RFC2046](https://json-schema.org/latest/json-schema-validation.html#RFC2046). (OPTIONAL)
+    - `default`: A default JSON value associated with a particular schema. RECOMMENDED that a default value be valid against the associated schema. (OPTIONAL)
+    - `definitions`: Provides a standardized location for bundle authors to inline re-usable JSON Schemas into a more general schema. MUST be an object where each named property contains a JSON schema. (OPTIONAL)
+    - `dependencies`: Specifies rules that are evaluated if the parameter type is an object and contains a certain property. MUST be an object where each named dependency is either an array of unique strings or a JSON schema. (OPTIONAL)
+    - `description`: Descriptive text for the field. Can be used to decorate a user interface. MUST be a string. (OPTIONAL)
     - `destination`: Indicates where (in the invocation image) the parameter is to be written (REQUIRED)
       - `env`: The name of an environment variable
       - `path`: The fully qualified path to a file that will be created
-    - `apply-to`: restricts this parameter to a given list of actions. If empty or missing, applies to all actions (OPTIONAL)
+    - `else`: Parameter validation requiring that the user-provided value match the specified schema. Only matches if the user-provided value does NOT match the schema provided in the `if` property. MUST be a JSON schema. (OPTIONAL)
+    - `enum`: Parameter validation requiring that the user-provided value is one of the specified items in the specified array. MUST be a non-empty array of unique elements that can be of any type. (OPTIONAL)
+    - `examples`: Sample JSON values associated with a particular schema. MUST be an array. (OPTIONAL)
+    - `exclusiveMaximum`: Parameter validation requiring that the user-provided number be less than the number specified. MUST be a number. (OPTIONAL)
+    - `exclusiveMinimum`: Parameter validation requiring that the user-provided number be greater than the number specified. MUST be a number. (OPTIONAL)
+    - `format`: Parameter validation requiring that the user-provided value adhere to the specified format. MUST be a string. (OPTIONAL)
+    - `if`: Provides a method to conditionally validate user-provided values against a schema. MUST be a JSON schema. (OPTIONAL)
+    - `items`: Parameter validation requiring the items included in a user-provided array must conform to the specified schema(s). MUST be either a JSON schema or an array of JSON schemas. (OPTIONAL)
+    - `maxItems`: Parameter validation requiring the length of the user-provided array be less than or equal to the number specified. MUST be a non-negative number. (OPTIONAL)
+    - `maxLength`: Parameter validation requiring that the length of the user-provided string be less than or equal to the number specified. MUST be a non-negative integer. (OPTIONAL)
+    - `maxProperties`: Parameter validation requiring the number of properties included in the user-provided object be less than or equal to the specified number. MUST be a non-negative integer. (OPTIONAL)
+    - `maximum`: Parameter validation requiring that the user-provided number be less than or equal to the number specified. MUST be a number. (OPTIONAL)
+    - `minItems`: Parameter validation requiring the length of the user-provided array be greater than or equal to the number specified. MUST be a non-negative number. (OPTIONAL)
+    - `minLength`: Parameter validation requiring that the length of the user-provided string be greater than or equal to the number specified. MUST be a non-negative integer. (OPTIONAL)
+    - `minProperties`: Parameter validation requiring the number of properties included in the user-provided object be greater than or equal to the specified number. MUST be a non-negative integer. (OPTIONAL)
+    - `minimum`: Parameter validation requiring that the user-provided number be greater than or equal to the number specified. MUST be a number. (OPTIONAL)
+    - `multipleOf`: Parameter validation requiring that the user-provided number be wholly divisible by the number specified. MUST be a number strictly greater than zero. (OPTIONAL)
+    - `not`: Parameter validation requiring that the user-provided value NOT match the specified schema. MUST be a JSON schema. (OPTIONAL)
+    - `oneOf`: Parameter validation requiring that the user-provided value match ONE of the specified schemas. MUST be a non-empty array of JSON schemas. (OPTIONAL)
+    - `patternProperties`: The set of matching properties and schemas for their values included in an object type parameter. MUST be an object where each named property is a regular expression with a JSON schema as the value. (OPTIONAL)
+    - `pattern`: Parameter validation requiring that the user-provided string match the regular expression specified. MUST be a string representation of a valid ECMA 262 regular expression. (OPTIONAL)
+    - `properties`: The set of named properties and schemas for their values included in an object type parameter. MUST be an object where each named property contains a JSON schema. (OPTIONAL)
+    - `propertyNames`: Parameter validation requiring that each property name in an object match the specified schema. MUST be a JSON schema. (OPTIONAL)
+    - `readOnly`: Indicates that the value of the parameter cannot be modified. MUST be a boolean. (OPTIONAL)
+    - `required`: Parameter validation requiring the properties named in the user-provided object include the specified list of properties. MUST be an array of strings. (OPTIONAL)
+    - `then`: Parameter validation requiring that the user-provided value match the specified schema. Only matches if the user-provided value matches the schema provided in the `if` property. MUST be a JSON schema. (OPTIONAL)
+    - `title`: Short, human-readable descriptive name for the field. Can be used to decorate a user interface. MUST be a string. (OPTIONAL)
+    - `type`: Parameter validation requiring that the user-provided value is either a "null", "boolean", "object", "array", "number", "string", or "integer". MUST be a string or an array of strings with unique elements. (OPTIONAL)
+    - `uniqueItems`: Parameter validation requiring the items included in the user-provided array be unique. MUST be a boolean. (OPTIONAL)
+
+For more information on the supported parameter properties, visit the [JSON Schema documentation](https://json-schema.org/)
 
 Parameter names (the keys in `parameters`) ought to conform to the [Open Group Base Specification Issue 6, Section 8.1, paragraph 4](http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html) definition of environment variable names with one exception: parameter names MAY begin with a digit (approximately `[A-Z0-9_]+`).
 
@@ -338,32 +371,182 @@ Some validation terms have aliased keywords for backward compatibility with ARM 
 
 > The term _parameters_ indicates the present specification of what can be provided to a bundle. The term _values_ is frequently used to indicate the user-supplied values which are tested against the parameter definitions.
 
+### Format of Parameter Specification
+
+The structure of a parameters section looks like the section below.
+
+```
+{
+  "parameters": {
+    "<parameter-name>": {
+      "$comment": <string>,
+      "$id": <uri-reference>,
+      "$ref": <uri-reference>,
+      "additionalItems": <json-schema>,
+      "additionalProperties": <json-schema>,
+      "allOf": [ <json-schema> ],
+      "anyOf": [ <json-schema> ],
+      "apply-to": [ <string> ],
+      "const": <any-value>,
+      "contains": <json-schema>,
+      "contentEncoding": <string>,
+      "contentMediaType": <string>,
+      "default": <any-value>,
+      "definitions": {
+        "<definition-name>": <json-schema>
+      },
+      "dependencies": {
+        "<first-property-name>": <json-schema>,
+        "<second-property-name>": [ <string> ]
+      },
+      "description": <string>,
+      "destination": {
+        "env": <string>,
+        "path": <string>
+      },
+      "else": <json-schema>,
+      "enum": [ <any-value> ],
+      "examples": [ <any-value> ],
+      "exclusiveMaximum": <number>,
+      "exclusiveMinimum": <number>,
+      "format": <string>,
+      "if": <json-schema>,
+      "items": <json-schema> | [ <json-schema> ],
+      "maxItems": <integer>,
+      "maxLength": <integer>,
+      "maxProperties": <integer>,
+      "maximum": <number>,
+      "minItems": <integer>,
+      "minLength": <integer>,
+      "minProperties": <integer>,
+      "minimum": <integer>,
+      "multipleOf": <number>,
+      "not": <json-schema>,
+      "oneOf": [ <json-schema> ],
+      "pattern": <string>,
+      "patternProperties": {
+        "<regular-expression-for-property-name>": <json-schema>
+      },
+      "properties": {
+        "<property-name>": <json-schema>
+      },
+      "propertyNames": <json-schema>,
+      "readOnly": <boolean>,
+      "required": [ <string> ],
+      "then": <json-schema>,
+      "title": <string>,
+      "type": <string> | [ <string> ],
+      "uniqueItems": boolean
+
+    },
+    "required": [ <string> ]
+  }
+}
+```
+
+See [The Bundle Runtime](103-bundle-runtime.md) for details of how parameters are injected into the invocation image.
+
+### Examples
+
+Below are a few more complicated examples that outline some of the possible parameter configurations that a bundle author can expose.
+
+Check out the [JSON Schema specification](https://json-schema.org/) for more examples and further documentation.
+
+```json
+{
+  "parameters": {
+    "address": {
+      "destination": {
+        "path": "/tmp/address.adr"
+      },
+      "properties": {
+        "country_name": {
+          "type": "string"
+        },
+        "extended_street_address": {
+          "type": "string"
+        },
+        "locality": {
+          "type": "string"
+        },
+        "postal_code": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "street_address": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "country_name",
+        "locality",
+        "postal_code",
+        "region",
+        "street_address"
+      ],
+      "type": "object"
+    },
+    "email": {
+      "format": "idn-email",
+      "type": "string"
+    },
+    "greetings": {
+      "default": [
+        "Hello"
+      ],
+      "description": "a list of greetings",
+      "destination": {
+        "env": "GREETINGS"
+      },
+      "items": {
+        "examples": [
+          "Bonjour",
+          "Aloha",
+          "こんにちは"
+        ],
+        "type": "string"
+      },
+      "title": "Greetings for new users",
+      "type": "array"
+    },
+    "image": {
+      "contentEncoding": "base64",
+      "contentMediaType": "image/jpeg",
+      "destination": {
+        "path": "/tmp/user.jpg"
+      },
+      "type": "string"
+    }
+  }
+}
+```
+
 ### Resolving Destinations
 
 When resolving destinations, there are two ways a particular parameter value MAY be placed into the invocation image. Here is an example illustrating both:
 
 ```json
-"parameters": {
-    "greeting": {
-        "defaultValue": "hello",
-        "type": "string",
-        "destination": {
-            "env": "GREETING"
-        },
-        "metadata":{
-            "description": "this will be in $GREETING"
-        }
-    },
+{
+  "parameters": {
     "config": {
-        "defaultValue": "",
-        "type": "string",
-        "destination": {
-            "path": "/opt/example-parameters/config.txt"
-        },
-        "metadata": {
-            "description": "this will be located in a file"
-        }
+      "default": "",
+      "description": "this will be located in a file",
+      "destination": {
+        "path": "/opt/example-parameters/config.txt"
+      },
+      "type": "string"
+    },
+    "greeting": {
+      "default": "hello",
+      "description": "this will be in $GREETING",
+      "destination": {
+        "env": "GREETING"
+      },
+      "type": "string"
     }
+  }
 }
 ```
 
@@ -374,35 +557,6 @@ If `env` is set, the value of the parameter will be assigned to the given enviro
 If `path` is set, the value of the parameter will be written into a file at the specified location on the invocation image's filesystem. This file name MUST NOT be present already on the invocation image's filesystem.
 
 If both `env` and `path` are specified, implementations MUST put a copy of the data in each destination.
-
-### Format of Parameter Specification
-
-The structure of a parameters section looks like this:
-
-```json
-"parameters": {
-    "<parameter-name>" : {
-        "type" : "<type-of-parameter-value>",
-        "required": true|false
-        "defaultValue": "<default-value-of-parameter>",
-        "allowedValues": [ "<array-of-allowed-values>" ],
-        "minValue": <minimum-value-for-int>,
-        "maxValue": <maximum-value-for-int>,
-        "minimum": <minimum-length-for-string-or-array>,
-        "maximum": <maximum-length-for-string-or-array-parameters>,
-        "metadata": {
-            "description": "<description-of-the parameter>"
-        },
-        "destination": {
-            "env": "<name-of-env-var>",
-            "path": "<fully-qualified-path>"
-        },
-        "apply-to": ["action1", "action2"]
-    }
-}
-```
-
-See [The Bundle Runtime](103-bundle-runtime.md) for details of how parameters are injected into the invocation image.
 
 ## Credentials
 

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -106,17 +106,17 @@ A CNAB `bundle.json` file MAY specify zero or more parameters whose values MAY b
 If the `destination` field contains a key named `env`, values MUST be passed into the container as environment variables, where the value of the `env` field is the name of the environment variable.
 
 ```json
-"parameters": {
+{
+  "parameters": {
     "greeting": {
-        "defaultValue": "hello",
-        "type": "string",
-        "destination": {
-            "env": "GREETING"
-        },
-        "metadata":{
-            "description": "this will be in $GREETING"
-        }
+      "default": "hello",
+      "description": "this will be in $GREETING",
+      "destination": {
+        "env": "GREETING"
+      },
+      "type": "string"
     }
+  }
 }
 ```
 
@@ -126,25 +126,25 @@ The parameter value is evaluated thus:
 
 - If the CNAB runtime provides a value, that value MAY be sanitized, then validated (as described below), then injected as the parameter value. In the event that sanitization or validation fail, the runtime SHOULD return an error and discontinue the action.
 - If the parameter is marked `required` and a value is not supplied, the CNAB Runtime MUST produce an error and discontinue action.
-- If the CNAB runtime does not provide a value, but `defaultValue` is set, then the default value MUST be used.
-- If no value is provided and `defaultValue` is unset, the runtime MUST set the value to an empty string (""), regardless of type.
+- If the CNAB runtime does not provide a value, but `default` is set, then the default value MUST be used.
+- If no value is provided and `default` is unset, the runtime MUST set the value to an empty string (""), regardless of type.
 
 > Setting the value of other types to a default value based on type, e.g. Boolean to `false` or integer to `0`, is considered _incorrect behavior_. Setting the value to `null`, `nil`, or a related character string is also considered incorrect.
 
 In the case where the `destination` object has a `path` field, the CNAB runtime MUST create a file at that path. The file MUST have sufficient permissions that the effective user ID of the image can read the contents of the file. And the contents of the file MUST be the parameter value (calculated according to the rules above).
 
 ```json
-"parameters": {
+{
+  "parameters": {
     "greeting": {
-        "defaultValue": "hello",
-        "type": "string",
-        "destination": {
-            "path": "/var/run/greeting.txt"
-        },
-        "metadata":{
-            "description": "this will be in $GREETING"
-        }
+      "default": "hello",
+      "description": "this will be in $GREETING",
+      "destination": {
+        "path": "/var/run/greeting.txt"
+      },
+      "type": "string"
     }
+  }
 }
 ```
 
@@ -156,7 +156,7 @@ If `destination` contains both a `path` and an `env`, the CNAB runtime MUST prov
 
 ### Validating parameters
 
-The validation of user-supplied values MUST happen outside of the CNAB bundle. Implementations of CNAB bundle tools MUST validate user-supplied values against the `parameters` section of a `bundle.json` before injecting them into the image. The outcome of successful validation MUST be the collection containing all parameters where either the user has supplied a value (that has been validated) or the `parameters` section of `bundles.json` contains a `defaultValue`.
+The validation of user-supplied values MUST happen outside of the CNAB bundle. Implementations of CNAB bundle tools MUST validate user-supplied values against the `parameters` section of a `bundle.json` before injecting them into the image. The outcome of successful validation MUST be the collection containing all parameters where either the user has supplied a value (that has been validated) or the `parameters` section of `bundles.json` contains a `default`.
 
 The resulting calculated values are injected into the bundle before the bundle's `run` is executed (and also in such a way that the `run` has access to these variables.) This works analogously to `CNAB_ACTION` and `CNAB_INSTALLATION_NAME`.
 
@@ -174,7 +174,7 @@ Credentials MAY be supplied as files on the file system. In such cases, the foll
 
 ## <a name="image-map">Image maps</a>
 
-At runtime the `image` section of the CNAB is mounted in file `/cnab/app/image-map.json`. 
+At runtime the `image` section of the CNAB is mounted in file `/cnab/app/image-map.json`.
 For this example CNAB bundle:
 
 ```json
@@ -216,16 +216,14 @@ For this example CNAB bundle:
   "name": "helloworld",
   "parameters": {
     "backend_port": {
-      "defaultValue": 80,
+      "default": 80,
       "destination": {
         "env": "BACKEND_PORT"
       },
-      "maxValue": 10240,
-      "metadata": {
-        "description": "The port that the back-end will listen on"
-      },
-      "minValue": 10,
-      "type": "int"
+      "maximum": 10240,
+      "description": "The port that the back-end will listen on",
+      "minimum": 10,
+      "type": "integer"
     }
   },
   "schemaVersion": "v1.0.0-WD",

--- a/104-bundle-formats.md
+++ b/104-bundle-formats.md
@@ -57,7 +57,7 @@ All images MUST be located inside of the `artifacts` directory.
 CNAB implementations MAY create other directories at the root of the archive.
 
 The contents of the `artifacts` directory SHOULD be either:
- 
+
 * a collection of image TAR files, for example:
     ```
     ├── artifacts
@@ -66,7 +66,7 @@ The contents of the `artifacts` directory SHOULD be either:
     └── bundle.json
     ```
     or
- 
+
 * an image layout in a subdirectory 'artifacts/layout' conforming to the [OCI Image Layout Specification](https://github.com/opencontainers/image-spec/blob/master/image-layout.md), for example:
     ```
     ├── artifacts
@@ -80,7 +80,7 @@ The contents of the `artifacts` directory SHOULD be either:
     │       └── oci-layout
     └── bundle.json
     ```
-    
+
 
 ### Transmitting Thick Bundles
 

--- a/400-claims.md
+++ b/400-claims.md
@@ -118,7 +118,7 @@ The parameter data stored in a claim data is _the resolved key/value pairs_ that
 - The values supplied by the user are validated by the rules specified in the `bundle.json` file
 - The output of this operation is a set of key/value pairs in which:
   - Valid user-supplied values are presented
-  - Default values are supplied for all parameters where `defaultValue` is provided and no user-supplied value overrides this
+  - Default values are supplied for all parameters where `default` is provided and no user-supplied value overrides this
 
 ### How is the Claim Used
 

--- a/examples/101.01-bundle.json
+++ b/examples/101.01-bundle.json
@@ -39,16 +39,14 @@
   "name": "helloworld",
   "parameters": {
     "backend_port": {
-      "defaultValue": 80,
+      "default": 80,
+      "description": "The port that the back-end will listen on",
       "destination": {
         "env": "BACKEND_PORT"
       },
-      "maxValue": 10240,
-      "metadata": {
-        "description": "The port that the back-end will listen on"
-      },
-      "minValue": 10,
-      "type": "int"
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
     }
   },
   "schemaVersion": "v1.0.0-WD",

--- a/examples/101.02-bundle.json
+++ b/examples/101.02-bundle.json
@@ -1,58 +1,56 @@
 {
-    "credentials": {
-      "hostkey": {
-        "env": "HOST_KEY",
-        "path": "/etc/hostkey.txt"
+  "credentials": {
+    "hostkey": {
+      "env": "HOST_KEY",
+      "path": "/etc/hostkey.txt"
+    },
+    "image_token": {
+      "env": "AZ_IMAGE_TOKEN"
+    },
+    "kubeconfig": {
+      "path": "/home/.kube/config"
+    }
+  },
+  "description": "An example 'thick' helloworld Cloud-Native Application Bundle",
+  "images": {
+    "my-microservice": {
+      "description": "helloworld microservice",
+      "digest": "sha256:bbbbbbbbbbbb...",
+      "image": "technosophos/helloworld:0.1.2",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
       },
-      "image_token": {
-        "env": "AZ_IMAGE_TOKEN"
+      "size": 1337
+    }
+  },
+  "invocationImages": [
+    {
+      "digest": "sha256:aaaaaaaaaaaa...",
+      "image": "technosophos/helloworld:1.2.3",
+      "imageType": "docker",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
       },
-      "kubeconfig": {
-        "path": "/home/.kube/config"
-      }
-    },
-    "description": "An example 'thick' helloworld Cloud-Native Application Bundle",
-    "images": {
-      "my-microservice": {
-        "description": "helloworld microservice",
-        "digest": "sha256:bbbbbbbbbbbb...",
-        "image": "technosophos/helloworld:0.1.2",
-        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-        "platform": {
-          "architecture": "amd64",
-          "os": "linux"
-        },
-        "size": 1337
-      }
-    },
-    "invocationImages": [
-      {
-        "digest": "sha256:aaaaaaaaaaaa...",
-        "image": "technosophos/helloworld:1.2.3",
-        "imageType": "docker",
-        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-        "platform": {
-          "architecture": "amd64",
-          "os": "linux"
-        },
-        "size": 1337
-      }
-    ],
-    "name": "helloworld",
-    "parameters": {
-      "backend_port": {
-        "defaultValue": 80,
-        "destination": {
-          "path": "/path/to/backend_port"
-        },
-        "maxValue": 10240,
-        "metadata": {
-          "description": "The port that the backend will listen on"
-        },
-        "minValue": 10,
-        "type": "int"
-      }
-    },
-    "schemaVersion": "v1.0.0-WD",
-    "version": "1.0.0"
-  }
+      "size": 1337
+    }
+  ],
+  "name": "helloworld",
+  "parameters": {
+    "backend_port": {
+      "default": 80,
+      "description": "The port that the backend will listen on",
+      "destination": {
+        "path": "/path/to/backend_port"
+      },
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
+    }
+  },
+  "schemaVersion": "v1.0.0-WD",
+  "version": "1.0.0"
+}

--- a/examples/103.1-bundle.json
+++ b/examples/103.1-bundle.json
@@ -36,16 +36,14 @@
   "name": "helloworld",
   "parameters": {
     "backend_port": {
-      "defaultValue": 80,
+      "default": 80,
+      "description": "The port that the back-end will listen on",
       "destination": {
         "env": "BACKEND_PORT"
       },
-      "maxValue": 10240,
-      "metadata": {
-        "description": "The port that the back-end will listen on"
-      },
-      "minValue": 10,
-      "type": "int"
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
     }
   },
   "schemaVersion": "v1.0.0-WD",

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -105,11 +105,16 @@
         "parameters":{
             "description": "Parameters that can be injected into the invocation image",
             "type": "object",
+            "properties": {
+                "required": { "$ref": "http://json-schema.org/draft-07/schema#/properties/required" }
+            },
             "additionalProperties": {
-                "$ref": "#/definitions/parameter"
+                "allOf": [
+                    { "$ref":  "#/definitions/parameter" },
+                    { "$ref":  "http://json-schema.org/draft-07/schema#" }
+                ]
             }
         }
-        
     },
     "required": [ "name", "version", "invocationImages", "schemaVersion"],
     "definitions": {
@@ -221,81 +226,9 @@
             }
         },
         "parameter": {
-            "description": "A paramter that can be passed into the invocation image",
+            "description": "A parameter that can be passed into the invocation image",
             "type": "object",
             "properties": {
-                "type": {
-                    "description": "The data type of the parameter",
-                    "type":"string",
-                    "pattern":"^(string|int|integer|numeric|null|boolean|bytes)$"
-                },
-                "required": {
-                    "description": "If true, this parameter must be supplied",
-                    "type": "boolean"
-                },
-                "defaultValue": {
-                    "description": "The default value of this parameter",
-                    "anyOf": [
-                        {"type": "string"},
-                        {"type": "integer"},
-                        {"type": "boolean"},
-                        {"type":"null"}
-                    ]
-                },
-                "allowedValues": {
-                    "description": "Alias of enum. Considered deprecated",
-                    "type":"array"
-                },
-                "enum": {
-                    "description": "An optional exhaustive list of allowed values",
-                    "type":"array"
-                },
-                "minValue": {
-                    "description": "Deprecated alias of minimum",
-                    "type": "integer"
-                },
-                "minimum": {
-                    "description": "Minimum numeric value (ignored for non-numeric/integer parameters)",
-                    "type": "integer"
-                },
-                "exclusiveMinimum": {
-                    "description": "Exclusive minimum numeric value (ignored for non-numeric/integer parameters)",
-                    "type": "integer"
-                },
-                "maxValue": {
-                    "description": "Deprecated alias of maximum",
-                    "type": "integer"
-                },
-                "maximum": {
-                    "description": "Maximum integer value (ignored for non-integer parameters)",
-                    "type": "integer"
-                },
-                "exclusiveMaximum": {
-                    "description": "Exclusive maximum integer value (ignored for non-integer parameters)",
-                    "type": "integer"
-                },
-                "minLength":{
-                    "description": "Minimum string length (ignored for non-string parameters)",
-                    "type": "integer"
-                },
-                "maxLength": {
-                    "description": "Maximum string length (ignored for non-string parameters)",
-                    "type": "integer"
-                },
-                "pattern": {
-                    "description": "ECMA 262 regular expression that must match a string value",
-                    "type": "string"
-                },
-                "metadata":{
-                    "description": "Extra data about the parameter",
-                    "type": "object",
-                    "properties": {
-                        "description": {
-                            "description": "Description of this parameter",
-                            "type":"string"
-                        }
-                    }
-                },
                 "destination": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
As requested during the March 27 community meeting, here is a new PR that outlines the proposal to change the `parameters` section to extend JSON Schema. The primary driver behind this PR is to provide more complex configuration inputs like arrays and object with significantly improved validation of those inputs. Additionally, this change serves to reduce confusion between the "JSON Schema"-alike `parameters` section of the current spec and JSON Schema.

This PR still leaves unresolved the concern of the representation of these complex parameter types inside the invocation image. If we support complex configuration then we will need the spec to make a determination on the format of that data when it is placed at a `destination`.

/cc @youreddy