### PR TITLE
Moves schema required field to correct location

### DIFF
--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -48,9 +48,9 @@
                         "description": "URL of the responsible party, perhaps containing additional contact info",
                         "type": "string"
                     }
-                }
-            },
-            "required": ["name"]
+                },
+                "required": ["name"]
+            }
         },
         "license":{
             "description": "The SPDX license code or proprietary license name for this bundle",


### PR DESCRIPTION
The "required" field only applies to "object" types and so should be
defined within the schema for a maintainer item, not the whole "maintainers" list.