### PR TITLE
add more info on governance

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -1,13 +1,15 @@
 # Governance
 
 ## Project Maintainers
-Project maintainers are responsible for activities around maintaining and updating the CNAB specification. Final decisions on the spec reside with the project maintainers.
+[Project maintainers](OWNERS) are responsible for activities around maintaining and updating the CNAB specification. Final decisions on the spec reside with the project maintainers.
 
 Maintainers MUST remain active. If they are unresponsive for >3 months, they will be automatically removed unless a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other project maintainers agrees to extend the period to be greater than 3 months.
 
-New maintainers can be added to the project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers.
+New maintainers can be added to the project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers. A potential maintainer may be nominated by an existing maintainer. A vote is conducted in private between the current maintainers over the course of a one week voting period. At the end of the week, votes are counted and a pull request is made on the repo adding the new maintainer to the [OWNERS](OWNERS) file.
 
 A maintainer may step down by submitting an [issue](https://github.com/deislabs/cnab-spec/issues/new) stating their intent.
+
+Changes to this governance document require a pull request with approval from a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the current maintainers.
 
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of conduct](https://opensource.microsoft.com/codeofconduct/).


### PR DESCRIPTION
Because this is the first governance change, I'll ask that we get an lgtm from each core maintainer on this PR. After this PR, only a super-majority will be required to make governance changes just like all other decisions for this repo.