### PR TITLE
Remove links to base bundles

### DIFF
--- a/802-credential-sets.md
+++ b/802-credential-sets.md
@@ -74,4 +74,4 @@ Credentials must be injected into the runtime of the invocation image. The follo
   - Injected at runtime into the top layer of the container
   - Loaded into VMs via cloud-init
 
-Next section: [Base Bundles](803-base-bundles.md)
+Next section: [Well known custom actions](804-well-known-custom-actions.md)

--- a/803-repositories.md
+++ b/803-repositories.md
@@ -9,4 +9,4 @@ CNAB bundles can be stored in [OCI Distribution-compliant repository](https://gi
 _This section is moved to [200-CNAB-registries](200-CNAB-registries.md)_
 
 
-Next section: [Well known custom actions](805-well-known-custom-actions.md)
+Next section: [Well known custom actions](804-well-known-custom-actions.md)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Cloud Native Application Bundles (CNAB) are a package format specification that 
 - Chapter 8: Non-normative Content
   1. [Declarative Invocation Images](801-declarative-images.md)
   1. [Credential Sets](802-credential-sets.md)
-  1. [The Base Bundle Pattern](803-base-bundles.md)
-  1. [Repositories](804-repositories.md)
+  1. [Repositories](803-repositories.md)
+  1. [Well known custom actions](804-well-known-custom-actions.md)
 - Chapter 9: Appendix
   1. [Appendix A: Preliminary Release Process](901-process.md)
 


### PR DESCRIPTION
Base bundles were removed from the spec in PR https://github.com/deislabs/cnab-spec/pull/154.

This PR cleans links to the removed spec