### PR TITLE
remove mention of drivers, which are specific to duffle

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -251,7 +251,7 @@ The following fields are informational pieces of metadata designed to convey add
 
 ## Invocation Images
 
-The `invocationImages` section describes the images that contain the bootstrapping for the image. The appropriate invocation image is selected by the CNAB runtime, typically by considering the runtime requirements of the bundle. For example, both a Windows and a Linux version of the invocation image may be included in the list. It is up to the CNAB runtime to determine which one to use. If no sufficient image is found, the CNAB runtime MUST emit an error and stop processing.
+The `invocationImages` section describes the images that are responsible for bootstrapping the installation. The appropriate invocation image is selected by the CNAB runtime, typically by considering the runtime requirements of the bundle. For example, both a Windows and a Linux version of the invocation image may be included in the list. It is up to the CNAB runtime to determine which one to use. If no sufficient image is found, the CNAB runtime MUST emit an error and stop processing.
 
 A CNAB bundle MUST have at least one invocation image.
 

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -251,7 +251,7 @@ The following fields are informational pieces of metadata designed to convey add
 
 ## Invocation Images
 
-The `invocationImages` section describes the images that contains the bootstrapping for the image. The appropriate invocation image is selected by the CNAB runtime, typically by considering the runtime requirements of the bundle. For example, both a Windows and a Linux version of the invocation image may be included in the list. It is up to the CNAB runtime to determine which one to use. If no sufficient image is found, the CNAB runtime MUST emit an error and stop processing.
+The `invocationImages` section describes the images that contain the bootstrapping for the image. The appropriate invocation image is selected by the CNAB runtime, typically by considering the runtime requirements of the bundle. For example, both a Windows and a Linux version of the invocation image may be included in the list. It is up to the CNAB runtime to determine which one to use. If no sufficient image is found, the CNAB runtime MUST emit an error and stop processing.
 
 A CNAB bundle MUST have at least one invocation image.
 

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -251,7 +251,7 @@ The following fields are informational pieces of metadata designed to convey add
 
 ## Invocation Images
 
-The `invocationImages` section describes the images that contains the bootstrapping for the image. The appropriate invocation image is selected using the current driver.
+The `invocationImages` section describes the images that contains the bootstrapping for the image. The appropriate invocation image is selected by the CNAB runtime, typically by considering the runtime requirements of the bundle. For example, both a Windows and a Linux version of the invocation image may be included in the list. It is up to the CNAB runtime to determine which one to use. If no sufficient image is found, the CNAB runtime MUST emit an error and stop processing.
 
 A CNAB bundle MUST have at least one invocation image.
 
@@ -266,8 +266,6 @@ A CNAB bundle MUST have at least one invocation image.
 ```
 
 The `imageType` field MUST describe the format of the image. The list of formats is open-ended, but any CNAB-compliant system MUST implement `docker` and `oci`. The default is `oci`.
-
-> [Duffle](https://github.com/deis/duffle), the reference implementation of a CNAB installer, introduces a layer of user-customizable drivers which are type-aware. Images MAY be delegated to drivers for installation.
 
 The `image` field MUST give a path-like or URI-like representation of the location of the image. It is REQUIRED. The expectation is that an installer should be able to locate the image (given the image type) without additional information.
 

--- a/102-invocation-image.md
+++ b/102-invocation-image.md
@@ -6,7 +6,7 @@ weight: 102
 # The Invocation Images
 
 The `invocationImages` section of a `bundle.json` MUST contain at least one image (the invocation image). This image MUST be formatted according to the specification laid out in the present document.
-The appropriate invocation image is selected using the current driver.
+The appropriate invocation image is selected by the CNAB runtime.
 
 When a bundle is executed, the invocation image will be retrieved (if necessary) and started. Credential, parameter and image map data is passed to it, and then its `run` tool is executed. (See [The Bundle Runtime](103-bundle-runtime.md) for details).
 

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -11,7 +11,7 @@ The [Invocation Image definition](102-invocation-image.md) specifies the layout 
 
 ## The Run Tool (Main Entry Point)
 
-The main entry point of a CNAB bundle MUST be located at `/cnab/app/run`. When a compliant driver executes a CNAB bundle, it MUST execute the `/cnab/app/run` tool. In addition, images used as invocation images SHOULD also default to running `/cnab/app/run`. For example, a `Dockerfile`'s `exec` array MUST point to this entry point.
+The main entry point of a CNAB bundle MUST be located at `/cnab/app/run`. When a compliant CNAB runtime executes a bundle, it MUST execute the `/cnab/app/run` tool. In addition, images used as invocation images SHOULD also default to running `/cnab/app/run`. For example, a `Dockerfile`'s `exec` array MUST point to this entry point.
 
 > A fixed location for the `run` tool is mandated because not all image formats provide an equivalent method for starting an application. A client implementation of CNAB MAY access the image and directly execute the path `/cnab/app/run`. It is also permissible, given tooling constraints, to set the default entry point to a different path.
 


### PR DESCRIPTION
This changes the language in several places. Instead of suggesting the _driver_ determines which invocation image is run, it now reads as the _CNAB runtime_ must select the driver.

Further, I added a clarification that if no sufficient image is found, the runtime must return an error.

Closes #180 
