### PR TITLE
add 'required' keyword for credentials

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -622,6 +622,7 @@ What about parameters such as database passwords used by the application? Proper
         "path": "/home/.kube/config"
     },
     "image_token": {
+        "required": true,
         "env": "AZ_IMAGE_TOKEN"
     },
     "hostkey": {
@@ -636,6 +637,7 @@ What about parameters such as database passwords used by the application? Proper
     - `path` describes the _absolute path within the invocation image_ where the invocation image expects to find the credential
     - `env` contains _the name of an environment variable_ that the invocation image expects to have available when executing the CNAB `run` tool (covered in the next section).
     - `description` contains a user-friendly description of the credential.
+    - `required` indicates whether this credential MUST be supplied. By default, it is `false`, which means the credential is optional. When `true`, a runtime MUST fail if the credential is not provided.
 
 When _both a path and an env_ are specified, _only one is REQUIRED_ (properties are disjunctive). To require two presentations of the same material, two separate entries MUST be made.
 

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -243,6 +243,11 @@
                 "description": {
                     "description": "A user-friendly description of this credential",
                     "type": "string"
+                },
+                "required": {
+                    "description": "Indicates whether this credential must be supplied. By default, credentials are optional.",
+                    "type": "boolean",
+                    "default": false
                 }
             }
         },


### PR DESCRIPTION
This adds a `required` property under `credentials`, and declares that all credentials are optional unless `required` is set to true.

Closes #119.