### PR TITLE
Factors JSONSchema definitions out of parameters

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -20,10 +20,11 @@ A `bundle.json` is broken down into the following categories of information:
   - `description`: Short description of the bundle
 - Information on the invocation images, as an array
 - A map of images included with this bundle, as a `component name` to `image definition` map
-- A specification of which parameters MAY be overridden, and how those are to be validated
+- A specification of which parameters MAY be overridden, and a reference to a validation schema
 - A list of credentials (name and desired location) that the application needs
 - An OPTIONAL description of custom actions that this bundle implements
 - A list of outputs (name, type and location) that the application produces
+- A set of schema definitions used to validate user input
 
 The `bundle.json` is also known as a _thin bundle_. Bundles come in two formats: thick and thin. Read more about thick and thin bundles in the [bundle formats section](104-bundle-formats.md).
 
@@ -46,6 +47,14 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
     "com.example.duffle-bag": {
       "icon": "https://example.com/icon.png",
       "iconType": "PNG"
+    }
+  },
+  "definitions": {
+    "http_port": {
+      "default": 80,
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
     }
   },
   "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
@@ -72,35 +81,34 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
   ],
   "name": "helloworld",
   "outputs": {
-    "clientCert" : {
-      "contentEncoding" : "base64",
-      "contentMediaType" : "application/x-x509-user-cert",
-      "path" : "/cnab/app/outputs/clientCert",
-      "sensitive" : true,
-      "type" : "file"
+    "clientCert": {
+      "contentEncoding": "base64",
+      "contentMediaType": "application/x-x509-user-cert",
+      "path": "/cnab/app/outputs/clientCert",
+      "sensitive": true,
+      "type": "file"
     },
-    "hostName" : {
-        "applyTo" : ["install"],
-        "description" : "the hostname produced installing the bundle",
-        "path" : "/cnab/app/outputs/hostname",
-        "type" : "string"
-     },
-    "port" : {
-      "path" : "/cnab/app/outputs/port",
-      "type" : "integer"
+    "hostName": {
+      "applyTo": [
+        "install"
+      ],
+      "description": "the hostname produced installing the bundle",
+      "path": "/cnab/app/outputs/hostname",
+      "type": "string"
+    },
+    "port": {
+      "path": "/cnab/app/outputs/port",
+      "type": "integer"
     }
   },
   "parameters": {
     "fields": {
       "backend_port": {
-        "default": 80,
+        "definition": "http_port",
+        "description": "The port that the back-end will listen on",
         "destination": {
           "env": "BACKEND_PORT"
-        },
-        "maximum": 10240,
-        "description": "The port that the back-end will listen on",
-        "minimum": 10,
-        "type": "integer"
+        }
       }
     }
   },
@@ -114,7 +122,7 @@ Source: [101.01-bundle.json](examples/101.01-bundle.json)
 The canonical JSON version of the above is:
 
 ```json
-{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"description":"my microservice","contentDigest":"sha256:aaaaaaaaaaaa...","image":"technosophos/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"clientCert":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","path":"/cnab/app/outputs/clientCert","sensitive":true,"type":"string"},"hostName":{"applyTo":["install"],"description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname","type":"string"},"port":{"path":"/cnab/app/outputs/port","type":"integer"}},"parameters":{"fields":{"backend_port":{"default":80,"description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"},"maximum":10240,"minimum":10,"type":"integer"}}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
+{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"technosophos/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"clientCert":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","path":"/cnab/app/outputs/clientCert","sensitive":true,"type":"file"},"hostName":{"applyTo":["install"],"description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname","type":"string"},"port":{"path":"/cnab/app/outputs/port","type":"integer"}},"parameters":{"fields":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
 ```
 
 And here is how a "thick" bundle looks. Notice how the `invocationImage` and `images` fields reference the underlying docker image manifest (`application/vnd.docker.distribution.manifest.v2+json`), which in turn references the underlying images:
@@ -131,6 +139,14 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
     },
     "kubeconfig": {
       "path": "/home/.kube/config"
+    }
+  },
+  "definitions": {
+    "http_port": {
+      "default": 80,
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
     }
   },
   "description": "An example 'thick' helloworld Cloud-Native Application Bundle",
@@ -162,35 +178,34 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
   ],
   "name": "helloworld",
   "outputs": {
-    "clientCert" : {
-      "contentEncoding" : "base64",
-      "contentMediaType" : "application/x-x509-user-cert",
-      "path" : "/cnab/app/outputs/clientCert",
-      "sensitive" : true,
-      "type" : "file"
+    "clientCert": {
+      "contentEncoding": "base64",
+      "contentMediaType": "application/x-x509-user-cert",
+      "path": "/cnab/app/outputs/clientCert",
+      "sensitive": true,
+      "type": "file"
     },
-    "hostName" : {
-        "applyTo" : ["install"],
-        "description" : "the hostname produced installing the bundle",
-        "path" : "/cnab/app/outputs/hostname",
-        "type" : "string"
-     },
-    "port" : {
-      "path" : "/cnab/app/outputs/port",
-      "type" : "integer"
+    "hostName": {
+      "applyTo": [
+        "install"
+      ],
+      "description": "the hostname produced installing the bundle",
+      "path": "/cnab/app/outputs/hostname",
+      "type": "string"
+    },
+    "port": {
+      "path": "/cnab/app/outputs/port",
+      "type": "integer"
     }
   },
   "parameters": {
-    "fields" : {
+    "fields": {
       "backend_port": {
-        "default": 80,
+        "definition": "http_port",
         "description": "The port that the backend will listen on",
         "destination": {
           "path": "/path/to/backend_port"
-        },
-        "maximum": 10240,
-        "minimum": 10,
-        "type": "integer"
+        }
       }
     }
   },
@@ -328,170 +343,187 @@ Fields:
 
 The image map data is made available to the invocation image at runtime. This allows invocation images to perform various substitutions during installation (for example, moving images to different storage mechanisms or registries, and renaming appropriately). See [Image map](103-bundle-runtime.md#image-map) for more details.
 
-## Parameters
+## Parameters & Definitions
 
-The `parameters` section of the `bundle.json` defines which parameters a user (person installing a CNAB bundle) MAY configure on an invocation image. Parameters represent information about the application configuration, and may be persisted by the runtime.
+The `parameters` and `definitions` sections of the `bundle.json` define which parameters a user (person installing a CNAB bundle) MAY configure on an invocation image and how those parameters should be validated by a runtime. Parameters represent information about the application configuration, and may be persisted by the runtime.
 
 Parameter specifications consist of name/value pairs. The name is fixed, but the value MAY be overridden by the user. The parameter definition includes a specification of how to constrain the values submitted by the user.
 
 ```json
 {
+  "definitions": {
+    "http_port": {
+      "default": 80,
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
+    }
+  },
   "parameters": {
-    "fields" : {
+    "fields": {
       "backend_port": {
         "applyTo": [
           "install",
           "action1",
           "action2"
         ],
-        "default": 80,
+        "definition": "http_port",
         "description": "The port that the backend will listen on",
         "destination": {
           "env": "MY_ENV_VAR",
           "path": "/my/destination/path"
-        },
-        "maximum": 10240,
-        "minimum": 10,
-        "type": "integer"
+        }
       }
     },
-    "required": ["backend_port"]
+    "required": [
+      "backend_port"
+    ]
+  }
 }
 ```
+
+- `definitions`: A collection of JSONSchema definitions used to validate user-input.
+  - `<name>`: The name of the definition.
+    - `$comment`: Reserved for comments from bundle authors to readers or maintainers of the bundle. This MUST be a string (OPTIONAL)
+    - `$id`: A URI for the schema resolved against the base URI of its parent schema. MUST be a uri-reference string in accordance with [RFC3986](https://tools.ietf.org/html/rfc3986) (OPTIONAL)
+    - `$ref`: A URI reference used to resolve a schema located elsewhere. This MUST be a uri-reference string in accordance with [RFC3986](https://tools.ietf.org/html/rfc3986) (OPTIONAL)
+    - `additionalItems`: Parameter validation requiring that any additional items included in a user-provided array must conform to the specified schema. MUST be a JSON schema. (OPTIONAL)
+    - `additionalProperties`: Parameter validation requiring that any additional properties in the user-provided object conform to the specified schema. MUST be a JSON schema. (OPTIONAL)
+    - `allOf`: Parameter validation requiring that the user-provided value match ALL of the specified schemas. MUST be a non-empty array of JSON schemas. (OPTIONAL)
+    - `anyOf`: Parameter validation requiring that the user-provided value match ANY of the specified schemas. MUST be a non-empty array of JSON schemas. (OPTIONAL)
+    - `const`: Parameter validation requiring that the user-provided value matches exactly the specified const. MAY be of any type, including null. (OPTIONAL)
+    - `contains`: Parameter validation requiring at least one item included in the user-provided array conform to the specified schema. MUST be a JSON schema. (OPTIONAL)
+    - `contentEncoding`: Indicates that the user-provided content should interpreted as binary data and decoded using the encoding named by this property. MUST be a string in accordance with [RFC2045, Sec 6.1](https://json-schema.org/latest/json-schema-validation.html#RFC2045). (OPTIONAL)
+    - `contentMediaType`: MIME type indicating the media type of the user-provided content. MUST be a string in accordance with [RFC2046](https://json-schema.org/latest/json-schema-validation.html#RFC2046). (OPTIONAL)
+    - `default`: A default JSON value associated with a particular schema. RECOMMENDED that a default value be valid against the associated schema. (OPTIONAL)
+    - `definitions`: Provides a standardized location for bundle authors to inline re-usable JSON Schemas into a more general schema. MUST be an object where each named property contains a JSON schema. (OPTIONAL)
+    - `dependencies`: Specifies rules that are evaluated if the parameter type is an object and contains a certain property. MUST be an object where each named dependency is either an array of unique strings or a JSON schema. (OPTIONAL)
+    - `description`: Descriptive text for the field. Can be used to decorate a user interface. MUST be a string. (OPTIONAL)
+    - `else`: Parameter validation requiring that the user-provided value match the specified schema. Only matches if the user-provided value does NOT match the schema provided in the `if` property. MUST be a JSON schema. (OPTIONAL)
+    - `enum`: Parameter validation requiring that the user-provided value is one of the specified items in the specified array. MUST be a non-empty array of unique elements that can be of any type. (OPTIONAL)
+    - `examples`: Sample JSON values associated with a particular schema. MUST be an array. (OPTIONAL)
+    - `exclusiveMaximum`: Parameter validation requiring that the user-provided number be less than the number specified. MUST be a number. (OPTIONAL)
+    - `exclusiveMinimum`: Parameter validation requiring that the user-provided number be greater than the number specified. MUST be a number. (OPTIONAL)
+    - `format`: Parameter validation requiring that the user-provided value adhere to the specified format. MUST be a string. (OPTIONAL)
+    - `if`: Provides a method to conditionally validate user-provided values against a schema. MUST be a JSON schema. (OPTIONAL)
+    - `items`: Parameter validation requiring the items included in a user-provided array must conform to the specified schema(s). MUST be either a JSON schema or an array of JSON schemas. (OPTIONAL)
+    - `maxItems`: Parameter validation requiring the length of the user-provided array be less than or equal to the number specified. MUST be a non-negative number. (OPTIONAL)
+    - `maxLength`: Parameter validation requiring that the length of the user-provided string be less than or equal to the number specified. MUST be a non-negative integer. (OPTIONAL)
+    - `maxProperties`: Parameter validation requiring the number of properties included in the user-provided object be less than or equal to the specified number. MUST be a non-negative integer. (OPTIONAL)
+    - `maximum`: Parameter validation requiring that the user-provided number be less than or equal to the number specified. MUST be a number. (OPTIONAL)
+    - `minItems`: Parameter validation requiring the length of the user-provided array be greater than or equal to the number specified. MUST be a non-negative number. (OPTIONAL)
+    - `minLength`: Parameter validation requiring that the length of the user-provided string be greater than or equal to the number specified. MUST be a non-negative integer. (OPTIONAL)
+    - `minProperties`: Parameter validation requiring the number of properties included in the user-provided object be greater than or equal to the specified number. MUST be a non-negative integer. (OPTIONAL)
+    - `minimum`: Parameter validation requiring that the user-provided number be greater than or equal to the number specified. MUST be a number. (OPTIONAL)
+    - `multipleOf`: Parameter validation requiring that the user-provided number be wholly divisible by the number specified. MUST be a number strictly greater than zero. (OPTIONAL)
+    - `not`: Parameter validation requiring that the user-provided value NOT match the specified schema. MUST be a JSON schema. (OPTIONAL)
+    - `oneOf`: Parameter validation requiring that the user-provided value match ONE of the specified schemas. MUST be a non-empty array of JSON schemas. (OPTIONAL)
+    - `patternProperties`: The set of matching properties and schemas for their values included in an object type parameter. MUST be an object where each named property is a regular expression with a JSON schema as the value. (OPTIONAL)
+    - `pattern`: Parameter validation requiring that the user-provided string match the regular expression specified. MUST be a string representation of a valid ECMA 262 regular expression. (OPTIONAL)
+    - `properties`: The set of named properties and schemas for their values included in an object type parameter. MUST be an object where each named property contains a JSON schema. (OPTIONAL)
+    - `propertyNames`: Parameter validation requiring that each property name in an object match the specified schema. MUST be a JSON schema. (OPTIONAL)
+    - `readOnly`: Indicates that the value of the parameter cannot be modified. MUST be a boolean. (OPTIONAL)
+    - `required`: Parameter validation requiring the properties named in the user-provided object include the specified list of properties. MUST be an array of strings. (OPTIONAL)
+    - `then`: Parameter validation requiring that the user-provided value match the specified schema. Only matches if the user-provided value matches the schema provided in the `if` property. MUST be a JSON schema. (OPTIONAL)
+    - `title`: Short, human-readable descriptive name for the field. Can be used to decorate a user interface. MUST be a string. (OPTIONAL)
+    - `type`: Parameter validation requiring that the user-provided value is either a "null", "boolean", "object", "array", "number", "string", or "integer". MUST be a string or an array of strings with unique elements. (OPTIONAL)
+    - `uniqueItems`: Parameter validation requiring the items included in the user-provided array be unique. MUST be a boolean. (OPTIONAL)
+    - `writeOnly`: Indicates that the value of the parameter is sensitive and cannot be viewed once set or updated. MUST be a boolean. (OPTIONAL)
+
+For more information on the supported definition properties, visit the [JSON Schema documentation](https://json-schema.org/)
+
+Evaluation of the validation keywords should conform to the applicable sections of [Section 6 of the JSONSchema specification](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6).
 
 - `parameters`: A collection of parameter definitions and a list of those parameters that are required.
   - `fields`: name/value pairs describing a user-overridable parameter:
     - `<name>`: The name of the parameter. In the example above, this is `backend_port`. This
     is mapped to a value definition, which contains the following fields (REQUIRED):
-      - `$comment`: Reserved for comments from bundle authors to readers or maintainers of the bundle. This MUST be a string (OPTIONAL)
-      - `$id`: A URI for the schema resolved against the base URI of its parent schema. MUST be a uri-reference string in accordance with [RFC3986](https://tools.ietf.org/html/rfc3986) (OPTIONAL)
-      - `$ref`: A URI reference used to resolve a schema located elsewhere. This MUST be a uri-reference string in accordance with [RFC3986](https://tools.ietf.org/html/rfc3986) (OPTIONAL)
-      - `additionalItems`: Parameter validation requiring that any additional items included in a user-provided array must conform to the specified schema. MUST be a JSON schema. (OPTIONAL)
-      - `additionalProperties`: Parameter validation requiring that any additional properties in the user-provided object conform to the specified schema. MUST be a JSON schema. (OPTIONAL)
-      - `allOf`: Parameter validation requiring that the user-provided value match ALL of the specified schemas. MUST be a non-empty array of JSON schemas. (OPTIONAL)
-      - `anyOf`: Parameter validation requiring that the user-provided value match ANY of the specified schemas. MUST be a non-empty array of JSON schemas. (OPTIONAL)
       - `applyTo`: restricts this parameter to a given list of actions. If empty or missing, applies to all actions (OPTIONAL)
-      - `const`: Parameter validation requiring that the user-provided value matches exactly the specified const. MAY be of any type, including null. (OPTIONAL)
-      - `contains`: Parameter validation requiring at least one item included in the user-provided array conform to the specified schema. MUST be a JSON schema. (OPTIONAL)
-      - `contentEncoding`: Indicates that the user-provided content should interpreted as binary data and decoded using the encoding named by this property. MUST be a string in accordance with [RFC2045, Sec 6.1](https://json-schema.org/latest/json-schema-validation.html#RFC2045). (OPTIONAL)
-      - `contentMediaType`: MIME type indicating the media type of the user-provided content. MUST be a string in accordance with [RFC2046](https://json-schema.org/latest/json-schema-validation.html#RFC2046). (OPTIONAL)
-      - `default`: A default JSON value associated with a particular schema. RECOMMENDED that a default value be valid against the associated schema. (OPTIONAL)
-      - `definitions`: Provides a standardized location for bundle authors to inline re-usable JSON Schemas into a more general schema. MUST be an object where each named property contains a JSON schema. (OPTIONAL)
-      - `dependencies`: Specifies rules that are evaluated if the parameter type is an object and contains a certain property. MUST be an object where each named dependency is either an array of unique strings or a JSON schema. (OPTIONAL)
+      - `definition`: The name of a definition schema that is used to validate user-input for this parameter. (REQUIRED)
       - `description`: Descriptive text for the field. Can be used to decorate a user interface. MUST be a string. (OPTIONAL)
       - `destination`: Indicates where (in the invocation image) the parameter is to be written (REQUIRED)
         - `env`: The name of an environment variable
         - `path`: The fully qualified path to a file that will be created. Specified path MUST NOT be a subpath of `/cnab/app/outputs`.
-      - `else`: Parameter validation requiring that the user-provided value match the specified schema. Only matches if the user-provided value does NOT match the schema provided in the `if` property. MUST be a JSON schema. (OPTIONAL)
-      - `enum`: Parameter validation requiring that the user-provided value is one of the specified items in the specified array. MUST be a non-empty array of unique elements that can be of any type. (OPTIONAL)
-      - `examples`: Sample JSON values associated with a particular schema. MUST be an array. (OPTIONAL)
-      - `exclusiveMaximum`: Parameter validation requiring that the user-provided number be less than the number specified. MUST be a number. (OPTIONAL)
-      - `exclusiveMinimum`: Parameter validation requiring that the user-provided number be greater than the number specified. MUST be a number. (OPTIONAL)
-      - `format`: Parameter validation requiring that the user-provided value adhere to the specified format. MUST be a string. (OPTIONAL)
-      - `if`: Provides a method to conditionally validate user-provided values against a schema. MUST be a JSON schema. (OPTIONAL)
-      - `items`: Parameter validation requiring the items included in a user-provided array must conform to the specified schema(s). MUST be either a JSON schema or an array of JSON schemas. (OPTIONAL)
-      - `maxItems`: Parameter validation requiring the length of the user-provided array be less than or equal to the number specified. MUST be a non-negative number. (OPTIONAL)
-      - `maxLength`: Parameter validation requiring that the length of the user-provided string be less than or equal to the number specified. MUST be a non-negative integer. (OPTIONAL)
-      - `maxProperties`: Parameter validation requiring the number of properties included in the user-provided object be less than or equal to the specified number. MUST be a non-negative integer. (OPTIONAL)
-      - `maximum`: Parameter validation requiring that the user-provided number be less than or equal to the number specified. MUST be a number. (OPTIONAL)
-      - `minItems`: Parameter validation requiring the length of the user-provided array be greater than or equal to the number specified. MUST be a non-negative number. (OPTIONAL)
-      - `minLength`: Parameter validation requiring that the length of the user-provided string be greater than or equal to the number specified. MUST be a non-negative integer. (OPTIONAL)
-      - `minProperties`: Parameter validation requiring the number of properties included in the user-provided object be greater than or equal to the specified number. MUST be a non-negative integer. (OPTIONAL)
-      - `minimum`: Parameter validation requiring that the user-provided number be greater than or equal to the number specified. MUST be a number. (OPTIONAL)
-      - `multipleOf`: Parameter validation requiring that the user-provided number be wholly divisible by the number specified. MUST be a number strictly greater than zero. (OPTIONAL)
-      - `not`: Parameter validation requiring that the user-provided value NOT match the specified schema. MUST be a JSON schema. (OPTIONAL)
-      - `oneOf`: Parameter validation requiring that the user-provided value match ONE of the specified schemas. MUST be a non-empty array of JSON schemas. (OPTIONAL)
-      - `patternProperties`: The set of matching properties and schemas for their values included in an object type parameter. MUST be an object where each named property is a regular expression with a JSON schema as the value. (OPTIONAL)
-      - `pattern`: Parameter validation requiring that the user-provided string match the regular expression specified. MUST be a string representation of a valid ECMA 262 regular expression. (OPTIONAL)
-      - `properties`: The set of named properties and schemas for their values included in an object type parameter. MUST be an object where each named property contains a JSON schema. (OPTIONAL)
-      - `propertyNames`: Parameter validation requiring that each property name in an object match the specified schema. MUST be a JSON schema. (OPTIONAL)
-      - `readOnly`: Indicates that the value of the parameter cannot be modified. MUST be a boolean. (OPTIONAL)
-      - `required`: Parameter validation requiring the properties named in the user-provided object include the specified list of properties. MUST be an array of strings. (OPTIONAL)
-      - `then`: Parameter validation requiring that the user-provided value match the specified schema. Only matches if the user-provided value matches the schema provided in the `if` property. MUST be a JSON schema. (OPTIONAL)
-      - `title`: Short, human-readable descriptive name for the field. Can be used to decorate a user interface. MUST be a string. (OPTIONAL)
-      - `type`: Parameter validation requiring that the user-provided value is either a "null", "boolean", "object", "array", "number", "string", or "integer". MUST be a string or an array of strings with unique elements. (OPTIONAL)
-      - `uniqueItems`: Parameter validation requiring the items included in the user-provided array be unique. MUST be a boolean. (OPTIONAL)
-      - `writeOnly`: Indicates that the value of the parameter is sensitive and cannot be viewed once set or updated. MUST be a boolean. (OPTIONAL)
   - `required`: A list of required parameters. MUST be an array of strings.(OPTIONAL)
-
-For more information on the supported parameter properties, visit the [JSON Schema documentation](https://json-schema.org/)
 
 Parameter names (the keys in `fields`) ought to conform to the [Open Group Base Specification Issue 6, Section 8.1, paragraph 4](http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html) definition of environment variable names with one exception: parameter names MAY begin with a digit (approximately `[A-Z0-9_]+`).
 
-Evaluation of the validation keywords should conform to the applicable sections of [Section 6 of the JSONSchema specification](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6).
-
-Some validation terms have aliased keywords for backward compatibility with ARM template validators. A CNAB runtime SHOULD implement all aliases. A CNAB builder SHOULD NOT prefer the aliases over the regular names. In this way, aliases will be phased out. The present syntax is based on a subset of JSONSchema's validators.
-
 > The term _parameters_ indicates the present specification of what can be provided to a bundle. The term _values_ is frequently used to indicate the user-supplied values which are tested against the parameter definitions.
 
-### Format of Parameter Specification
+### Format of Parameter/Definition Specification
 
-The structure of a parameters section looks like the section below.
+The structure of a `parameters` and `definitions` section looks like the section below.
 
 ```
 {
+  "definitions: {
+    "<definition-name>": {
+      "$comment": <string>,
+      "$id": <uri-reference>,
+      "$ref": <uri-reference>,
+      "additionalItems": <json-schema>,
+      "additionalProperties": <json-schema>,
+      "allOf": [ <json-schema> ],
+      "anyOf": [ <json-schema> ],
+      "const": <any-value>,
+      "contains": <json-schema>,
+      "contentEncoding": <string>,
+      "contentMediaType": <string>,
+      "default": <any-value>,
+      "definitions": {
+        "<definition-name>": <json-schema>
+      },
+      "dependencies": {
+        "<first-property-name>": <json-schema>,
+        "<second-property-name>": [ <string> ]
+      },
+      "description": <string>,
+      "else": <json-schema>,
+      "enum": [ <any-value> ],
+      "examples": [ <any-value> ],
+      "exclusiveMaximum": <number>,
+      "exclusiveMinimum": <number>,
+      "format": <string>,
+      "if": <json-schema>,
+      "items": <json-schema> | [ <json-schema> ],
+      "maxItems": <integer>,
+      "maxLength": <integer>,
+      "maxProperties": <integer>,
+      "maximum": <number>,
+      "minItems": <integer>,
+      "minLength": <integer>,
+      "minProperties": <integer>,
+      "minimum": <integer>,
+      "multipleOf": <number>,
+      "not": <json-schema>,
+      "oneOf": [ <json-schema> ],
+      "pattern": <string>,
+      "patternProperties": {
+        "<regular-expression-for-property-name>": <json-schema>
+      },
+      "properties": {
+        "<property-name>": <json-schema>
+      },
+      "propertyNames": <json-schema>,
+      "readOnly": <boolean>,
+      "required": [ <string> ],
+      "then": <json-schema>,
+      "title": <string>,
+      "type": <string> | [ <string> ],
+      "uniqueItems": <boolean>,
+      "writeOnly": <boolean>
+    }
+  },
   "parameters": {
     "fields" : {
       "<parameter-name>": {
-        "$comment": <string>,
-        "$id": <uri-reference>,
-        "$ref": <uri-reference>,
-        "additionalItems": <json-schema>,
-        "additionalProperties": <json-schema>,
-        "allOf": [ <json-schema> ],
-        "anyOf": [ <json-schema> ],
         "applyTo": [ <string> ],
-        "const": <any-value>,
-        "contains": <json-schema>,
-        "contentEncoding": <string>,
-        "contentMediaType": <string>,
-        "default": <any-value>,
-        "definitions": {
-          "<definition-name>": <json-schema>
-        },
-        "dependencies": {
-          "<first-property-name>": <json-schema>,
-          "<second-property-name>": [ <string> ]
-        },
+        "definition": <definition-name>,
         "description": <string>,
         "destination": {
           "env": <string>,
           "path": <string>
-        },
-        "else": <json-schema>,
-        "enum": [ <any-value> ],
-        "examples": [ <any-value> ],
-        "exclusiveMaximum": <number>,
-        "exclusiveMinimum": <number>,
-        "format": <string>,
-        "if": <json-schema>,
-        "items": <json-schema> | [ <json-schema> ],
-        "maxItems": <integer>,
-        "maxLength": <integer>,
-        "maxProperties": <integer>,
-        "maximum": <number>,
-        "minItems": <integer>,
-        "minLength": <integer>,
-        "minProperties": <integer>,
-        "minimum": <integer>,
-        "multipleOf": <number>,
-        "not": <json-schema>,
-        "oneOf": [ <json-schema> ],
-        "pattern": <string>,
-        "patternProperties": {
-          "<regular-expression-for-property-name>": <json-schema>
-        },
-        "properties": {
-          "<property-name>": <json-schema>
-        },
-        "propertyNames": <json-schema>,
-        "readOnly": <boolean>,
-        "required": [ <string> ],
-        "then": <json-schema>,
-        "title": <string>,
-        "type": <string> | [ <string> ],
-        "uniqueItems": <boolean>,
-        "writeOnly": <boolean>
+        }
       }
     },
     "required": [ <string> ]
@@ -509,75 +541,95 @@ Check out the [JSON Schema specification](https://json-schema.org/) for more exa
 
 ```json
 {
-  "parameters": {
-    "fields" : {
-      "address": {
-        "destination": {
-          "path": "/tmp/address.adr"
-        },
-        "properties": {
-          "country_name": {
-            "type": "string"
-          },
-          "extended_street_address": {
-            "type": "string"
-          },
-          "locality": {
-            "type": "string"
-          },
-          "postal_code": {
-            "type": "string"
-          },
-          "region": {
-            "type": "string"
-          },
-          "street_address": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "country_name",
-          "locality",
-          "postal_code",
-          "region",
-          "street_address"
-        ],
-        "type": "object"
-      },
-      "email": {
-        "format": "idn-email",
-        "type": "string"
-      },
-      "greetings": {
-        "default": [
-          "Hello"
-        ],
-        "description": "a list of greetings",
-        "destination": {
-          "env": "GREETINGS"
-        },
-        "items": {
-          "examples": [
-            "Bonjour",
-            "Aloha",
-            "こんにちは"
-          ],
+  "definitions": {
+    "address": {
+      "properties": {
+        "country_name": {
           "type": "string"
         },
-        "title": "Greetings for new users",
-        "type": "array"
+        "extended_street_address": {
+          "type": "string"
+        },
+        "locality": {
+          "type": "string"
+        },
+        "postal_code": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "street_address": {
+          "type": "string"
+        }
       },
-      "image": {
-        "contentEncoding": "base64",
-        "contentMediaType": "image/jpeg",
+      "required": [
+        "country_name",
+        "locality",
+        "postal_code",
+        "region",
+        "street_address"
+      ],
+      "type": "object"
+    },
+    "email-address": {
+      "format": "idn-email",
+      "type": "string"
+    },
+    "greetings": {
+      "default": [
+        "Hello"
+      ],
+      "description": "a list of greetings",
+      "items": {
+        "examples": [
+          "Bonjour",
+          "Aloha",
+          "こんにちは"
+        ],
+        "type": "string"
+      },
+      "title": "Greetings for new users",
+      "type": "array"
+    },
+    "jpeg": {
+      "contentEncoding": "base64",
+      "contentMediaType": "image/jpeg",
+      "type": "string"
+    }
+  },
+  "parameters": {
+    "fields": {
+      "workplace_address": {
+        "definition": "address",
+        "description": "the address of your workplace",
+        "destination": {
+          "path": "/tmp/address.adr"
+        }
+      },
+      "email": {
+        "definition": "email-address",
+        "destination": {
+          "env": "EMAIL"
+        }
+      },
+      "greetings": {
+        "definition": "greetings",
+        "destination": {
+          "env": "GREETINGS"
+        }
+      },
+      "profile_picture": {
+        "definition": "jpeg",
         "destination": {
           "path": "/tmp/user.jpg"
-        },
-        "type": "string"
+        }
       }
     }
   },
-  "required" : [ "address" ]
+  "required": [
+    "workplace_address"
+  ]
 }
 ```
 
@@ -587,23 +639,31 @@ When resolving destinations, there are two ways a particular parameter value MAY
 
 ```json
 {
+  "definitions": {
+    "configuration": {
+      "default": "",
+      "type": "string"
+    },
+    "greeting": {
+      "default": "hello",
+      "type": "string"
+    }
+  },
   "parameters": {
-    "fields" : {
+    "fields": {
       "config": {
-        "default": "",
+        "definition": "configuration",
         "description": "this will be located in a file",
         "destination": {
           "path": "/opt/example-parameters/config.txt"
-        },
-        "type": "string"
+        }
       },
       "greeting": {
-        "default": "hello",
+        "definition": "greeting",
         "description": "this will be in $GREETING",
         "destination": {
           "env": "GREETING"
-        },
-        "type": "string"
+        }
       }
     }
   }

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -107,15 +107,20 @@ If the `destination` field contains a key named `env`, values MUST be passed int
 
 ```json
 {
+  "definitions": {
+    "greeting": {
+      "default": "hello",
+      "type": "string"
+    }
+  },
   "parameters": {
-    "fields" : {
+    "fields": {
       "greeting": {
-        "default": "hello",
+        "definition": "greeting",
         "description": "this will be in $GREETING",
         "destination": {
           "env": "GREETING"
-        },
-        "type": "string"
+        }
       }
     }
   }
@@ -137,15 +142,20 @@ In the case where the `destination` object has a `path` field, the CNAB runtime 
 
 ```json
 {
+  "definitions": {
+    "greeting": {
+      "default": "hello",
+      "type": "string"
+    }
+  },
   "parameters": {
-    "fields" : {
+    "fields": {
       "greeting": {
-        "default": "hello",
+        "definition": "greeting",
         "description": "this will be in $GREETING",
         "destination": {
           "path": "/var/run/greeting.txt"
-        },
-        "type": "string"
+        }
       }
     }
   }
@@ -160,7 +170,7 @@ If `destination` contains both a `path` and an `env`, the CNAB runtime MUST prov
 
 ### Validating parameters
 
-The validation of user-supplied values MUST happen outside of the CNAB bundle. Implementations of CNAB bundle tools MUST validate user-supplied values against the `parameters` section of a `bundle.json` before injecting them into the image. The outcome of successful validation MUST be the collection containing all parameters where either the user has supplied a value (that has been validated) or the `parameters` section of `bundles.json` contains a `default`.
+The validation of user-supplied values MUST happen outside of the CNAB bundle. Implementations of CNAB bundle tools MUST validate user-supplied parameter values against the named schema in the `definitions` section of a `bundle.json` before injecting them into the image. The outcome of successful validation MUST be the collection containing all parameters where either the user has supplied a value (that has been validated) or the name definition in the `definitions` section of `bundles.json` contains a `default`.
 
 The resulting calculated values are injected into the bundle before the bundle's `run` is executed (and also in such a way that the `run` has access to these variables.) This works analogously to `CNAB_ACTION` and `CNAB_INSTALLATION_NAME`.
 
@@ -195,6 +205,14 @@ For this example CNAB bundle:
       "path": "/home/.kube/config"
     }
   },
+  "definitions": {
+    "http_port": {
+      "default": 80,
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
+    }
+  },
   "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
   "images": {
     "my-microservice": {
@@ -220,16 +238,13 @@ For this example CNAB bundle:
   ],
   "name": "helloworld",
   "parameters": {
-    "fields" : {
+    "fields": {
       "backend_port": {
-        "default": 80,
+        "definition": "http_port",
+        "description": "The port that the back-end will listen on",
         "destination": {
           "env": "BACKEND_PORT"
-        },
-        "maximum": 10240,
-        "description": "The port that the back-end will listen on",
-        "minimum": 10,
-        "type": "integer"
+        }
       }
     }
   },

--- a/examples/101.01-bundle.json
+++ b/examples/101.01-bundle.json
@@ -14,6 +14,14 @@
       "iconType": "PNG"
     }
   },
+  "definitions": {
+    "http_port": {
+      "default": 80,
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
+    }
+  },
   "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
   "images": {
     "my-microservice": {
@@ -38,35 +46,34 @@
   ],
   "name": "helloworld",
   "outputs": {
-    "clientCert" : {
-      "contentEncoding" : "base64",
-      "contentMediaType" : "application/x-x509-user-cert",
-      "path" : "/cnab/app/outputs/clientCert",
-      "sensitive" : true,
-      "type" : "string"
+    "clientCert": {
+      "contentEncoding": "base64",
+      "contentMediaType": "application/x-x509-user-cert",
+      "path": "/cnab/app/outputs/clientCert",
+      "sensitive": true,
+      "type": "string"
     },
-    "hostName" : {
-        "applyTo" : ["install"],
-        "description" : "the hostname produced installing the bundle",
-        "path" : "/cnab/app/outputs/hostname",
-        "type" : "string"
-     },
-    "port" : {
-      "path" : "/cnab/app/outputs/port",
-      "type" : "integer"
+    "hostName": {
+      "applyTo": [
+        "install"
+      ],
+      "description": "the hostname produced installing the bundle",
+      "path": "/cnab/app/outputs/hostname",
+      "type": "string"
+    },
+    "port": {
+      "path": "/cnab/app/outputs/port",
+      "type": "integer"
     }
   },
   "parameters": {
-    "fields" : {
+    "fields": {
       "backend_port": {
-        "default": 80,
+        "definition": "http_port",
         "description": "The port that the back-end will listen on",
         "destination": {
           "env": "BACKEND_PORT"
-        },
-        "maximum": 10240,
-        "minimum": 10,
-        "type": "integer"
+        }
       }
     }
   },

--- a/examples/101.02-bundle.json
+++ b/examples/101.02-bundle.json
@@ -11,6 +11,14 @@
       "path": "/home/.kube/config"
     }
   },
+  "definitions": {
+    "http_port": {
+      "default": 80,
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
+    }
+  },
   "description": "An example 'thick' helloworld Cloud-Native Application Bundle",
   "images": {
     "my-microservice": {
@@ -40,35 +48,34 @@
   ],
   "name": "helloworld",
   "outputs": {
-    "clientCert" : {
-      "contentEncoding" : "base64",
-      "contentMediaType" : "application/x-x509-user-cert",
-      "path" : "/cnab/app/outputs/clientCert",
-      "sensitive" : true,
-      "type" : "string"
+    "clientCert": {
+      "contentEncoding": "base64",
+      "contentMediaType": "application/x-x509-user-cert",
+      "path": "/cnab/app/outputs/clientCert",
+      "sensitive": true,
+      "type": "string"
     },
-    "hostName" : {
-        "applyTo" : ["install"],
-        "description" : "the hostname produced installing the bundle",
-        "path" : "/cnab/app/outputs/hostname",
-        "type" : "string"
-     },
-    "port" : {
-      "path" : "/cnab/app/outputs/port",
-      "type" : "integer"
+    "hostName": {
+      "applyTo": [
+        "install"
+      ],
+      "description": "the hostname produced installing the bundle",
+      "path": "/cnab/app/outputs/hostname",
+      "type": "string"
+    },
+    "port": {
+      "path": "/cnab/app/outputs/port",
+      "type": "integer"
     }
   },
   "parameters": {
-    "fields" : {
+    "fields": {
       "backend_port": {
-        "default": 80,
+        "definition": "http_port",
         "description": "The port that the backend will listen on",
         "destination": {
           "path": "/path/to/backend_port"
-        },
-        "maximum": 10240,
-        "minimum": 10,
-        "type": "integer"
+        }
       }
     }
   },

--- a/examples/103.1-bundle.json
+++ b/examples/103.1-bundle.json
@@ -11,6 +11,14 @@
       "path": "/home/.kube/config"
     }
   },
+  "definitions": {
+    "http_port": {
+      "default": 80,
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
+    }
+  },
   "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
   "images": {
     "my-microservice": {
@@ -36,15 +44,14 @@
   ],
   "name": "helloworld",
   "parameters": {
-    "backend_port": {
-      "default": 80,
-      "description": "The port that the back-end will listen on",
-      "destination": {
-        "env": "BACKEND_PORT"
-      },
-      "maximum": 10240,
-      "minimum": 10,
-      "type": "integer"
+    "fields": {
+      "backend_port": {
+        "definition": "http_port",
+        "description": "The port that the back-end will listen on",
+        "destination": {
+          "env": "BACKEND_PORT"
+        }
+      }
     }
   },
   "schemaVersion": "v1.0.0-WD",

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -102,6 +102,12 @@
         "custom":{
             "$comment": "reserved for custom extensions"
         },
+        "definitions": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "http://json-schema.org/draft-07/schema#"
+          }
+        },
         "parameters":{
             "description": "Parameters that can be injected into the invocation image",
             "type": "object",
@@ -109,15 +115,11 @@
                 "fields" : {
                     "type": "object",
                     "additionalProperties": {
-                        "allOf": [
-                            { "$ref":  "#/definitions/parameter" },
-                            { "$ref":  "http://json-schema.org/draft-07/schema#" }
-                        ]
+                        "$ref":  "#/definitions/parameter"
                     }
                 },
                 "required": { "$ref": "http://json-schema.org/draft-07/schema#/properties/required" }
             }
-           
         },
         "outputs":{
             "description": "Values that are produced by executing the invocation image",
@@ -244,7 +246,6 @@
                     "description": "The environment variable name, such as MY_VALUE, into which the credential will be placed",
                     "type": "string"
                 },
-                
                 "description": {
                     "description": "A user-friendly description of this credential",
                     "type": "string"
@@ -260,6 +261,11 @@
             "description": "A parameter that can be passed into the invocation image",
             "type": "object",
             "properties": {
+                "definition": {
+                  "type": "string",
+                  "description": "The name of a definition that describes the schema structure of this parameter"
+                },
+                "description": { "$ref": "http://json-schema.org/draft-07/schema#/properties/description" },
                 "destination": {
                     "type": "object",
                     "properties": {
@@ -274,7 +280,7 @@
                         }
                     }
                 },
-                "applyTo":{                    
+                "applyTo":{
                     "description": "An optional exhaustive list of actions handling this parameter",
                     "type":"array",
                     "items": {
@@ -282,13 +288,13 @@
                     }
                 }
             },
-            "required": ["type", "destination"]
+            "required": ["definition", "destination"]
         },
         "output": {
             "description": "A value that is produced by running an invocation image",
             "type": "object",
             "properties": {
-                "applyTo":{                    
+                "applyTo":{
                     "description": "An optional exhaustive list of actions producing this output",
                     "type":"array",
                     "items": {
@@ -300,7 +306,6 @@
                     "type": "string",
                     "pattern": "^\/cnab\/app\/outputs\/.+$"
                 }
-                
             },
             "required": ["type", "path"]
         }


### PR DESCRIPTION
- these schema are now defined by name in a top-level field called
  "definitions"
- parameters will define the schema for their field by referencing the
  name of a definition in their own "definition" field

This did not touch the `outputs` section, but it would make sense to also factor the validation for those fields out to this same top-level `definitions` field. That would separate the concerns of validation from those of naming and exposing those user inputs during invocation.