### PR TITLE
Thick bundles no longer store images in multiple TAR files

### DIFF
--- a/104-bundle-formats.md
+++ b/104-bundle-formats.md
@@ -47,39 +47,28 @@ A thick bundle SHOULD be encoded as a gzipped TAR. This specification is neutral
 The internal layout of the TAR SHOULD be as follows:
 ```
 ├── artifacts
-│   └── ...
+│   └── layout
+│       └── ...
 └── bundle.json
 ```
-The `bundle.json` MUST always be located at the root of the archive.
 
-All images MUST be located inside of the `artifacts` directory.
+The `bundle.json` MUST always be located at the root of the archive.
 
 CNAB implementations MAY create other directories at the root of the archive.
 
-The contents of the `artifacts` directory SHOULD be either:
-
-* a collection of image TAR files, for example:
-    ```
-    ├── artifacts
-    │   ├── example.com-technosophos-invocation-image-1.2.3.tar
-    │   └── example.com-technosophos-microservice-latest.tar
-    └── bundle.json
-    ```
-    or
-
-* an image layout in a subdirectory 'artifacts/layout' conforming to the [OCI Image Layout Specification](https://github.com/opencontainers/image-spec/blob/master/image-layout.md), for example:
-    ```
-    ├── artifacts
-    │   └── layout
-    │       ├── blobs
-    │       │   └── sha256
-    │       │       ├── 3588d02542238316759cbf24502f4344ffcc8a60c803870022f335d1390c13b4
-    │       │       ├── 4b0bc1c4050b03c95ef2a8e36e25feac42fd31283e8c30b3ee5df6b043155d3c
-    │       │       └── 7968321274dc6b6171697c33df7815310468e694ac5be0ec03ff053bb135e768
-    │       ├── index.json
-    │       └── oci-layout
-    └── bundle.json
-    ```
+All images MUST be located inside of the `artifacts/layout` directory, the contents of which SHOULD be an image layout conforming to the [OCI Image Layout Specification](https://github.com/opencontainers/image-spec/blob/master/image-layout.md), for example:
+```
+├── artifacts
+│   └── layout
+│       ├── blobs
+│       │   └── sha256
+│       │       ├── 3588d02542238316759cbf24502f4344ffcc8a60c803870022f335d1390c13b4
+│       │       ├── 4b0bc1c4050b03c95ef2a8e36e25feac42fd31283e8c30b3ee5df6b043155d3c
+│       │       └── 7968321274dc6b6171697c33df7815310468e694ac5be0ec03ff053bb135e768
+│       ├── index.json
+│       └── oci-layout
+└── bundle.json
+```
 
 
 ### Transmitting Thick Bundles


### PR DESCRIPTION
Fixes https://github.com/deislabs/cnab-spec/issues/182
Fixes https://github.com/deislabs/cnab-spec/issues/171