### PR TITLE
Cleanup text in credentials section

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -717,7 +717,6 @@ If `env` is set, the value of the credential MUST be assigned to the given envir
 
 If `path` is set, the value of the credential MUST be written into a file at the specified location on the invocation image's filesystem. This file name MUST NOT be present already on the invocation image's filesystem.
 
-If both `env` and `path` are specified, implementations MUST put a copy of the data in each destination.
 
 ### Resolving Destination Conflicts in Environment Variables and Paths
 

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -715,7 +715,7 @@ One of `env` or `path` MUST be specified. (Both MAY be provided).
 
 If `env` is set, the value of the credential MUST be assigned to the given environment variable name. In the example in the previous section, `HOST_KEY` is set to `HOST_KEY`.
 
-If `path` is set, the value of the credential will be written into a file at the specified location on the invocation image's filesystem. This file name MUST NOT be present already on the invocation image's filesystem.
+If `path` is set, the value of the credential MUST be written into a file at the specified location on the invocation image's filesystem. This file name MUST NOT be present already on the invocation image's filesystem.
 
 If both `env` and `path` are specified, implementations MUST put a copy of the data in each destination.
 

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -713,7 +713,7 @@ What about parameters such as database passwords used by the application? Proper
 
 One of `env` or `path` MUST be specified. (Both MAY be provided).
 
-If `env` is set, the value of the credential will be assigned to the given environment variable name. In the example in the previous section, `HOST_KEY` is set to `HOST_KEY`.
+If `env` is set, the value of the credential MUST be assigned to the given environment variable name. In the example in the previous section, `HOST_KEY` is set to `HOST_KEY`.
 
 If `path` is set, the value of the credential will be written into a file at the specified location on the invocation image's filesystem. This file name MUST NOT be present already on the invocation image's filesystem.
 

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -711,7 +711,13 @@ What about parameters such as database passwords used by the application? Proper
     - `description` contains a user-friendly description of the credential.
     - `required` indicates whether this credential MUST be supplied. By default, it is `false`, which means the credential is optional. When `true`, a runtime MUST fail if the credential is not provided.
 
-When _both a path and an env_ are specified, _only one is REQUIRED_ (properties are disjunctive). To require two presentations of the same material, two separate entries MUST be made.
+One of `env` or `path` MUST be specified. (Both MAY be provided).
+
+If `env` is set, the value of the credential will be assigned to the given environment variable name. In the example in the previous section, `HOST_KEY` is set to `HOST_KEY`.
+
+If `path` is set, the value of the credential will be written into a file at the specified location on the invocation image's filesystem. This file name MUST NOT be present already on the invocation image's filesystem.
+
+If both `env` and `path` are specified, implementations MUST put a copy of the data in each destination.
 
 ### Resolving Destination Conflicts in Environment Variables and Paths
 


### PR DESCRIPTION
This cleans up the text in the credentials section as highlighted by #198 and makes it similar to what we have defined for parameters. 