### PR TITLE
Factors JSONSchema fields out of outputs

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -55,13 +55,27 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
       "maximum": 10240,
       "minimum": 10,
       "type": "integer"
+    },
+    "port": {
+      "maximum": 65535,
+      "minimum": 1024,
+      "type": "integer"
+    },
+    "string": {
+      "type": "string"
+    },
+    "x509Certificate": {
+      "contentEncoding": "base64",
+      "contentMediaType": "application/x-x509-user-cert",
+      "type": "string",
+      "writeOnly": true
     }
   },
   "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
   "images": {
     "my-microservice": {
-      "description": "my microservice",
       "contentDigest": "sha256:aaaaaaaaaaaa...",
+      "description": "my microservice",
       "image": "technosophos/microservice:1.2.3"
     }
   },
@@ -81,24 +95,23 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
   ],
   "name": "helloworld",
   "outputs": {
-    "clientCert": {
-      "contentEncoding": "base64",
-      "contentMediaType": "application/x-x509-user-cert",
-      "path": "/cnab/app/outputs/clientCert",
-      "sensitive": true,
-      "type": "file"
-    },
-    "hostName": {
-      "applyTo": [
-        "install"
-      ],
-      "description": "the hostname produced installing the bundle",
-      "path": "/cnab/app/outputs/hostname",
-      "type": "string"
-    },
-    "port": {
-      "path": "/cnab/app/outputs/port",
-      "type": "integer"
+    "fields": {
+      "clientCert": {
+        "definition": "x509Certificate",
+        "path": "/cnab/app/outputs/clientCert"
+      },
+      "hostName": {
+        "applyTo": [
+          "install"
+        ],
+        "definition": "string",
+        "description": "the hostname produced installing the bundle",
+        "path": "/cnab/app/outputs/hostname"
+      },
+      "port": {
+        "definition": "port",
+        "path": "/cnab/app/outputs/port"
+      }
     }
   },
   "parameters": {
@@ -122,7 +135,7 @@ Source: [101.01-bundle.json](examples/101.01-bundle.json)
 The canonical JSON version of the above is:
 
 ```json
-{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"technosophos/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"clientCert":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","path":"/cnab/app/outputs/clientCert","sensitive":true,"type":"file"},"hostName":{"applyTo":["install"],"description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname","type":"string"},"port":{"path":"/cnab/app/outputs/port","type":"integer"}},"parameters":{"fields":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
+{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"},"port":{"maximum":65535,"minimum":1024,"type":"integer"},"string":{"type":"string"},"x509Certificate":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","type":"string","writeOnly":true}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"technosophos/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"fields":{"clientCert":{"definition":"x509Certificate","path":"/cnab/app/outputs/clientCert"},"hostName":{"applyTo":["install"],"definition":"string","description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname"},"port":{"definition":"port","path":"/cnab/app/outputs/port"}}},"parameters":{"fields":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
 ```
 
 And here is how a "thick" bundle looks. Notice how the `invocationImage` and `images` fields reference the underlying docker image manifest (`application/vnd.docker.distribution.manifest.v2+json`), which in turn references the underlying images:
@@ -147,13 +160,27 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
       "maximum": 10240,
       "minimum": 10,
       "type": "integer"
+    },
+    "port": {
+      "maximum": 65535,
+      "minimum": 1024,
+      "type": "integer"
+    },
+    "string": {
+      "type": "string"
+    },
+    "x509Certificate": {
+      "contentEncoding": "base64",
+      "contentMediaType": "application/x-x509-user-cert",
+      "type": "string",
+      "writeOnly": true
     }
   },
   "description": "An example 'thick' helloworld Cloud-Native Application Bundle",
   "images": {
     "my-microservice": {
-      "description": "helloworld microservice",
       "contentDigest": "sha256:bbbbbbbbbbbb...",
+      "description": "helloworld microservice",
       "image": "technosophos/helloworld:0.1.2",
       "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
       "platform": {
@@ -178,24 +205,23 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
   ],
   "name": "helloworld",
   "outputs": {
-    "clientCert": {
-      "contentEncoding": "base64",
-      "contentMediaType": "application/x-x509-user-cert",
-      "path": "/cnab/app/outputs/clientCert",
-      "sensitive": true,
-      "type": "file"
-    },
-    "hostName": {
-      "applyTo": [
-        "install"
-      ],
-      "description": "the hostname produced installing the bundle",
-      "path": "/cnab/app/outputs/hostname",
-      "type": "string"
-    },
-    "port": {
-      "path": "/cnab/app/outputs/port",
-      "type": "integer"
+    "fields": {
+      "clientCert": {
+        "definition": "x509Certificate",
+        "path": "/cnab/app/outputs/clientCert"
+      },
+      "hostName": {
+        "applyTo": [
+          "install"
+        ],
+        "definition": "string",
+        "description": "the hostname produced installing the bundle",
+        "path": "/cnab/app/outputs/hostname"
+      },
+      "port": {
+        "definition": "port",
+        "path": "/cnab/app/outputs/port"
+      }
     }
   },
   "parameters": {
@@ -343,44 +369,12 @@ Fields:
 
 The image map data is made available to the invocation image at runtime. This allows invocation images to perform various substitutions during installation (for example, moving images to different storage mechanisms or registries, and renaming appropriately). See [Image map](103-bundle-runtime.md#image-map) for more details.
 
-## Parameters & Definitions
+## Definitions
 
-The `parameters` and `definitions` sections of the `bundle.json` define which parameters a user (person installing a CNAB bundle) MAY configure on an invocation image and how those parameters should be validated by a runtime. Parameters represent information about the application configuration, and may be persisted by the runtime.
+The `definitions` section of the `bundle.json` defines set of JSONSchema definitions outlining how bundle configuration should be validated by a runtime.
 
-Parameter specifications consist of name/value pairs. The name is fixed, but the value MAY be overridden by the user. The parameter definition includes a specification of how to constrain the values submitted by the user.
-
-```json
-{
-  "definitions": {
-    "http_port": {
-      "default": 80,
-      "maximum": 10240,
-      "minimum": 10,
-      "type": "integer"
-    }
-  },
-  "parameters": {
-    "fields": {
-      "backend_port": {
-        "applyTo": [
-          "install",
-          "action1",
-          "action2"
-        ],
-        "definition": "http_port",
-        "description": "The port that the backend will listen on",
-        "destination": {
-          "env": "MY_ENV_VAR",
-          "path": "/my/destination/path"
-        }
-      }
-    },
-    "required": [
-      "backend_port"
-    ]
-  }
-}
-```
+Definitions have no utility on their own. They enable the runtime to validate parameters and outputs when used in combination with those features. Examples
+of how to use `definitions` along with `parameters` and `outputs` can be seen in the [Parameters](#parameters) and [Outputs](#outputs) sections below.
 
 - `definitions`: A collection of JSONSchema definitions used to validate user-input.
   - `<name>`: The name of the definition.
@@ -433,6 +427,45 @@ Parameter specifications consist of name/value pairs. The name is fixed, but the
 For more information on the supported definition properties, visit the [JSON Schema documentation](https://json-schema.org/)
 
 Evaluation of the validation keywords should conform to the applicable sections of [Section 6 of the JSONSchema specification](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6).
+
+## Parameters
+
+The `parameters` and `definitions` sections of the `bundle.json` define which parameters a user (person installing a CNAB bundle) MAY configure on an invocation image and how those parameters should be validated by a runtime. Parameters represent information about the application configuration, and may be persisted by the runtime.
+
+Parameter specifications consist of name/value pairs. The name is fixed, but the value MAY be overridden by the user. The parameter definition includes a specification of how to constrain the values submitted by the user.
+
+```json
+{
+  "definitions": {
+    "http_port": {
+      "default": 80,
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
+    }
+  },
+  "parameters": {
+    "fields": {
+      "backend_port": {
+        "applyTo": [
+          "install",
+          "action1",
+          "action2"
+        ],
+        "definition": "http_port",
+        "description": "The port that the backend will listen on",
+        "destination": {
+          "env": "MY_ENV_VAR",
+          "path": "/my/destination/path"
+        }
+      }
+    },
+    "required": [
+      "backend_port"
+    ]
+  }
+}
+```
 
 - `parameters`: A collection of parameter definitions and a list of those parameters that are required.
   - `fields`: name/value pairs describing a user-overridable parameter:
@@ -816,81 +849,61 @@ The usage of extensions is undefined. However, bundles SHOULD be installable by 
 
 The `outputs` section of the `bundle.json` defines which outputs an application will produce during the course of executing a bundle. Outputs are expected to be written to one or more files on the file system of the invocation image. The location of this file MUST be provided in the output definition.
 
-Output specifications are flat (not tree-like), consisting of name/value pairs. The output definition includes a destination the output will be written to, along with a type to help bundle users identify how to consume them.
+Output specifications are flat (not tree-like), consisting of name/value pairs. The output definition includes a destination the output will be written to, along with a definition to help validate their contents.
 
 ```json
-"outputs" : {
-  "clientCert" : {
-        "contentEncoding" : "base64",
-        "contentMediaType" : "application/x-x509-user-cert",
-        "type" : "string",
-        "path" : "/cnab/app/outputs/clientCert",
-        "applyTo": ["install", "action2"],
-        "sensitive" : true,
+{
+  "definitions": {
+    "port": {
+      "maximum": 65535,
+      "minimum": 1024,
+      "type": "integer"
     },
-    "hostName" : {
-        "type" : "string",
-        "path" : "/cnab/app/outputs/hostname"
+    "string": {
+      "type": "string"
     },
-    "port" : {
-        "type" : "integer",
-        "path" : "/cnab/app/outputs/port"
+    "x509Certificate": {
+      "contentEncoding": "base64",
+      "contentMediaType": "application/x-x509-user-cert",
+      "type": "string",
+      "writeOnly": true
     }
+  },
+  "outputs": {
+    "fields": {
+      "clientCert": {
+        "applyTo": [
+          "install",
+          "action2"
+        ],
+        "definition": "x509Certificate",
+        "path": "/cnab/app/outputs/clientCert"
+      },
+      "hostName": {
+        "definition": "string",
+        "path": "/cnab/app/outputs/hostname"
+      },
+      "port": {
+        "definition": "port",
+        "path": "/cnab/app/outputs/port"
+      }
+    }
+  }
 }
 ```
 
 - `outputs`: name/value pairs describing an application output
-  - `<name>`: The name of the output. In the example above, this is `clientCert`, `hostName`, and `port`. This is mapped to a value definition, which contains the following fields (REQUIRED):
-    - `$comment`: Reserved for comments from bundle authors to readers or maintainers of the bundle. This MUST be a string (OPTIONAL)
-    - `$id`: A URI for the schema resolved against the base URI of its parent schema. MUST be a uri-reference string in accordance with [RFC3986](https://tools.ietf.org/html/rfc3986) (OPTIONAL)
-    - `$ref`: A URI reference used to resolve a schema located elsewhere. This MUST be a uri-reference string in accordance with [RFC3986](https://tools.ietf.org/html/rfc3986) (OPTIONAL)
-    - `additionalItems`: Output validation requiring that any additional items included in a resulting array must conform to the specified schema. MUST be a JSON schema. (OPTIONAL)
-    - `additionalProperties`: Output validation requiring that any additional properties in the resulting object conform to the specified schema. MUST be a JSON schema. (OPTIONAL)
-    - `allOf`: Output validation requiring that the resulting value match ALL of the specified schemas. MUST be a non-empty array of JSON schemas. (OPTIONAL)
-    - `anyOf`: Output validation requiring that the resulting value match ANY of the specified schemas. MUST be a non-empty array of JSON schemas. (OPTIONAL)
-    - `applyTo`: restricts this output to a given list of actions. If empty or missing, applies to all actions (OPTIONAL)
-    - `const`: Output validation requiring that the resulting value matches exactly the specified const. MAY be of any type, including null. (OPTIONAL)
-    - `contains`: Output validation requiring at least one item included in the resulting array conform to the specified schema. MUST be a JSON schema. (OPTIONAL)
-    - `contentEncoding`: Indicates that the resulting content should interpreted as binary data and decoded using the encoding named by this property. MUST be a string in accordance with [RFC2045, Sec 6.1](https://json-schema.org/latest/json-schema-validation.html#RFC2045). (OPTIONAL)
-    - `contentMediaType`: MIME type indicating the media type of the resulting content. MUST be a string in accordance with [RFC2046](https://json-schema.org/latest/json-schema-validation.html#RFC2046). (OPTIONAL)
-    - `default`: A default JSON value associated with a particular schema. RECOMMENDED that a default value be valid against the associated schema. (OPTIONAL)
-    - `definitions`: Provides a standardized location for bundle authors to inline re-usable JSON Schemas into a more general schema. MUST be an object where each named property contains a JSON schema. (OPTIONAL)
-    - `dependencies`: Specifies rules that are evaluated if the output type is an object and contains a certain property. MUST be an object where each named dependency is either an array of unique strings or a JSON schema. (OPTIONAL)
-    - `description`: Descriptive text for the field. Can be used to decorate a user interface. MUST be a string. (OPTIONAL)
-    - `else`: Output validation requiring that the resulting value match the specified schema. Only matches if the resulting value does NOT match the schema provided in the `if` property. MUST be a JSON schema. (OPTIONAL)
-    - `enum`: Output validation requiring that the resulting value is one of the specified items in the specified array. MUST be a non-empty array of unique elements that can be of any type. (OPTIONAL)
-    - `examples`: Sample JSON values associated with a particular schema. MUST be an array. (OPTIONAL)
-    - `exclusiveMaximum`: Output validation requiring that the resulting number be less than the number specified. MUST be a number. (OPTIONAL)
-    - `exclusiveMinimum`: Output validation requiring that the resulting number be greater than the number specified. MUST be a number. (OPTIONAL)
-    - `format`: Output validation requiring that the resulting value adhere to the specified format. MUST be a string. (OPTIONAL)
-    - `if`: Provides a method to conditionally validate resulting values against a schema. MUST be a JSON schema. (OPTIONAL)
-    - `items`: Output validation requiring the items included in a resulting array must conform to the specified schema(s). MUST be either a JSON schema or an array of JSON schemas. (OPTIONAL)
-    - `maxItems`: Output validation requiring the length of the resulting array be less than or equal to the number specified. MUST be a non-negative number. (OPTIONAL)
-    - `maxLength`: Output validation requiring that the length of the resulting string be less than or equal to the number specified. MUST be a non-negative integer. (OPTIONAL)
-    - `maxProperties`: Output validation requiring the number of properties included in the resulting object be less than or equal to the specified number. MUST be a non-negative integer. (OPTIONAL)
-    - `maximum`: Output validation requiring that the resulting number be less than or equal to the number specified. MUST be a number. (OPTIONAL)
-    - `minItems`: Output validation requiring the length of the resulting array be greater than or equal to the number specified. MUST be a non-negative number. (OPTIONAL)
-    - `minLength`: Output validation requiring that the length of the resulting string be greater than or equal to the number specified. MUST be a non-negative integer. (OPTIONAL)
-    - `minProperties`: Output validation requiring the number of properties included in the resulting object be greater than or equal to the specified number. MUST be a non-negative integer. (OPTIONAL)
-    - `minimum`: Output validation requiring that the resulting number be greater than or equal to the number specified. MUST be a number. (OPTIONAL)
-    - `multipleOf`: Output validation requiring that the resulting number be wholly divisible by the number specified. MUST be a number strictly greater than zero. (OPTIONAL)
-    - `not`: Output validation requiring that the resulting value NOT match the specified schema. MUST be a JSON schema. (OPTIONAL)
-    - `oneOf`: Output validation requiring that the resulting value match ONE of the specified schemas. MUST be a non-empty array of JSON schemas. (OPTIONAL)
-    - `path`: The fully qualified path to a file that will be created (REQUIRED). The path specified MUST be a _strict_ subpath of `/cnab/app/outputs` and MUST be distinct from the paths for all other outputs in this bundle.
-    - `patternProperties`: The set of matching properties and schemas for their values included in an object type output. MUST be an object where each named property is a regular expression with a JSON schema as the value. (OPTIONAL)
-    - `pattern`: Output validation requiring that the resulting string match the regular expression specified. MUST be a string representation of a valid ECMA 262 regular expression. (OPTIONAL)
-    - `properties`: The set of named properties and schemas for their values included in an object type output. MUST be an object where each named property contains a JSON schema. (OPTIONAL)
-    - `propertyNames`: Output validation requiring that each property name in an object match the specified schema. MUST be a JSON schema. (OPTIONAL)
-    - `sensitive`: Indicates that a runtime should treat the output as a sensitive value. Defaults to false (OPTIONAL)
-    - `then`: Output validation requiring that the resulting value match the specified schema. Only matches if the resulting value matches the schema provided in the `if` property. MUST be a JSON schema. (OPTIONAL)
-    - `title`: Short, human-readable descriptive name for the field. Can be used to decorate a user interface. MUST be a string. (OPTIONAL)
-    - `type`: Output validation requiring that the resulting value is either a "null", "boolean", "object", "array", "number", "string", or "integer". MUST be a string or an array of strings with unique elements. (OPTIONAL)
-    - `uniqueItems`: Output validation requiring the items included in the resulting array be unique. MUST be a boolean. (OPTIONAL)
+  - `fields`: name/value pairs describing outputs:
+    - `<name>`: The name of the output. In the example above, this is `clientCert`, `hostName`, and `port`. This is mapped to a value definition, which contains the following fields (REQUIRED):
+      - `applyTo`: restricts this output to a given list of actions. If empty or missing, applies to all actions (OPTIONAL)
+      - `definition`: The name of a definition schema that is used to validate the output content. (REQUIRED)
+      - `description`: Descriptive text for the field. Can be used to decorate a user interface. MUST be a string. (OPTIONAL)
+      - `path`: The fully qualified path to a file that will be created (REQUIRED). The path specified MUST be a _strict_ subpath of `/cnab/app/outputs` and MUST be distinct from the paths for all other outputs in this bundle.
 
-An invocation image should write outputs to a file specified by the `path` attribute for each output. A bundle runtime can then extract values from the specified path and present them to a user. A runtime can leverage appropriate [in-memory](https://docs.docker.com/v17.09/engine/admin/volumes/tmpfs/#choosing-the-tmpfs-or-mount-flag) volume mounted at the `path` location for storing these outputs.
+An invocation image should write outputs to a file specified by the `path` attribute for each output. A bundle runtime can then extract values from the specified path and present them to a user.
+All outputs that apply to a specified action are considered to be required. If an output is missing at the end of an action, the runtime should report this condition as an error to the user.
+A runtime can leverage appropriate [in-memory](https://docs.docker.com/v17.09/engine/admin/volumes/tmpfs/#choosing-the-tmpfs-or-mount-flag) volume mounted at the `path` location for storing these outputs.
 
-For more information on the supported output properties, visit the [JSON Schema documentation](https://json-schema.org/)
-
-A runtime may validate outputs. Evaluation of the validation keywords should conform to the applicable sections of [Section 6 of the JSONSchema specification](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6).
+A runtime may validate outputs based on schema references by the definition field.
 
 Next section: [The invocation image definition](102-invocation-image.md)

--- a/examples/101.01-bundle.json
+++ b/examples/101.01-bundle.json
@@ -20,13 +20,27 @@
       "maximum": 10240,
       "minimum": 10,
       "type": "integer"
+    },
+    "port": {
+      "maximum": 65535,
+      "minimum": 1024,
+      "type": "integer"
+    },
+    "string": {
+      "type": "string"
+    },
+    "x509Certificate": {
+      "contentEncoding": "base64",
+      "contentMediaType": "application/x-x509-user-cert",
+      "type": "string",
+      "writeOnly": true
     }
   },
   "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
   "images": {
     "my-microservice": {
-      "description": "my microservice",
       "contentDigest": "sha256:aaaaaaaaaaaa...",
+      "description": "my microservice",
       "image": "technosophos/microservice:1.2.3"
     }
   },
@@ -46,24 +60,23 @@
   ],
   "name": "helloworld",
   "outputs": {
-    "clientCert": {
-      "contentEncoding": "base64",
-      "contentMediaType": "application/x-x509-user-cert",
-      "path": "/cnab/app/outputs/clientCert",
-      "sensitive": true,
-      "type": "string"
-    },
-    "hostName": {
-      "applyTo": [
-        "install"
-      ],
-      "description": "the hostname produced installing the bundle",
-      "path": "/cnab/app/outputs/hostname",
-      "type": "string"
-    },
-    "port": {
-      "path": "/cnab/app/outputs/port",
-      "type": "integer"
+    "fields": {
+      "clientCert": {
+        "definition": "x509Certificate",
+        "path": "/cnab/app/outputs/clientCert"
+      },
+      "hostName": {
+        "applyTo": [
+          "install"
+        ],
+        "definition": "string",
+        "description": "the hostname produced installing the bundle",
+        "path": "/cnab/app/outputs/hostname"
+      },
+      "port": {
+        "definition": "port",
+        "path": "/cnab/app/outputs/port"
+      }
     }
   },
   "parameters": {

--- a/examples/101.02-bundle.json
+++ b/examples/101.02-bundle.json
@@ -17,13 +17,27 @@
       "maximum": 10240,
       "minimum": 10,
       "type": "integer"
+    },
+    "port": {
+      "maximum": 65535,
+      "minimum": 1024,
+      "type": "integer"
+    },
+    "string": {
+      "type": "string"
+    },
+    "x509Certificate": {
+      "contentEncoding": "base64",
+      "contentMediaType": "application/x-x509-user-cert",
+      "type": "string",
+      "writeOnly": true
     }
   },
   "description": "An example 'thick' helloworld Cloud-Native Application Bundle",
   "images": {
     "my-microservice": {
-      "description": "helloworld microservice",
       "contentDigest": "sha256:bbbbbbbbbbbb...",
+      "description": "helloworld microservice",
       "image": "technosophos/helloworld:0.1.2",
       "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
       "platform": {
@@ -48,24 +62,23 @@
   ],
   "name": "helloworld",
   "outputs": {
-    "clientCert": {
-      "contentEncoding": "base64",
-      "contentMediaType": "application/x-x509-user-cert",
-      "path": "/cnab/app/outputs/clientCert",
-      "sensitive": true,
-      "type": "string"
-    },
-    "hostName": {
-      "applyTo": [
-        "install"
-      ],
-      "description": "the hostname produced installing the bundle",
-      "path": "/cnab/app/outputs/hostname",
-      "type": "string"
-    },
-    "port": {
-      "path": "/cnab/app/outputs/port",
-      "type": "integer"
+    "fields": {
+      "clientCert": {
+        "definition": "x509Certificate",
+        "path": "/cnab/app/outputs/clientCert"
+      },
+      "hostName": {
+        "applyTo": [
+          "install"
+        ],
+        "definition": "string",
+        "description": "the hostname produced installing the bundle",
+        "path": "/cnab/app/outputs/hostname"
+      },
+      "port": {
+        "definition": "port",
+        "path": "/cnab/app/outputs/port"
+      }
     }
   },
   "parameters": {

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -125,13 +125,12 @@
             "description": "Values that are produced by executing the invocation image",
             "type": "object",
             "properties": {
-                "required": { "$ref": "http://json-schema.org/draft-07/schema#/properties/required" }
-            },
-            "additionalProperties": {
-                "allOf": [
-                    { "$ref":  "#/definitions/output" },
-                    { "$ref":  "http://json-schema.org/draft-07/schema#" }
-                ]
+                "fields": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref":  "#/definitions/output"
+                    }
+                }
             }
         }
     },
@@ -301,13 +300,18 @@
                         "type": "string"
                     }
                 },
+                "definition": {
+                  "type": "string",
+                  "description": "The name of a definition that describes the schema structure of this output"
+                },
+                "description": { "$ref": "http://json-schema.org/draft-07/schema#/properties/description" },
                 "path":{
                     "description": "The path inside of the invocation image where output will be written",
                     "type": "string",
                     "pattern": "^\/cnab\/app\/outputs\/.+$"
                 }
             },
-            "required": ["type", "path"]
+            "required": ["definition", "path"]
         }
     },
     "additionalProperties": false


### PR DESCRIPTION
This PR includes changes to push outputs into a sub-object called `fields` and to introduce a new `required` array at that same level. Doing so brings outputs fully inline with the current experience for `parameters`.

Resolves https://github.com/deislabs/cnab-spec/issues/197