### PR TITLE
Formatting and whitespace corrections

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -303,13 +303,15 @@ The `invocationImages` section describes the images that are responsible for boo
 A CNAB bundle MUST have at least one invocation image.
 
 ```json
-"invocationImages": [
+{
+  "invocationImages": [
     {
-        "contentDigest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
-        "image": "technosophos/helloworld:0.1.0",
-        "imageType": "docker"
+      "contentDigest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
+      "image": "technosophos/helloworld:0.1.0",
+      "imageType": "docker"
     }
-]
+  ]
+}
 ```
 
 The `imageType` field MUST describe the format of the image. The list of formats is open-ended, but any CNAB-compliant system MUST implement `docker` and `oci`. The default is `oci`.
@@ -335,21 +337,20 @@ The following illustrates an `images` section:
 
 ```json
 {
-"images": {
-        "frontend": { 
-            "description": "frontend component image",
-            "imageType": "docker",
-            "image": "example.com/gabrtv/vote-frontend@sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
-            "originalImage": "example.com/opendeis/vote-frontend@sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
-            "contentDigest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685"
-        },
-        "backend": {
-            "description": "backend component image",
-            "imageType": "docker",
-            "image": "example.com/gabrtv/vote-backend@sha256:bca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120686",
-            "originalImage": "example.com/opendeis/vote-backend@sha256:bca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120686",
-            "contentDigest": "sha256:bca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120686"
-        }
+  "images": {
+    "backend": {
+      "contentDigest": "sha256:bca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120686",
+      "description": "backend component image",
+      "image": "example.com/gabrtv/vote-backend@sha256:bca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120686",
+      "imageType": "docker",
+      "originalImage": "example.com/opendeis/vote-backend@sha256:bca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120686"
+    },
+    "frontend": {
+      "contentDigest": "sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
+      "description": "frontend component image",
+      "image": "example.com/gabrtv/vote-frontend@sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685",
+      "imageType": "docker",
+      "originalImage": "example.com/opendeis/vote-frontend@sha256:aca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120685"
     }
   }
 }
@@ -618,8 +619,8 @@ Check out the [JSON Schema specification](https://json-schema.org/) for more exa
       "description": "a list of greetings",
       "items": {
         "examples": [
-          "Bonjour",
           "Aloha",
+          "Bonjour",
           "こんにちは"
         ],
         "type": "string"
@@ -635,13 +636,6 @@ Check out the [JSON Schema specification](https://json-schema.org/) for more exa
   },
   "parameters": {
     "fields": {
-      "workplace_address": {
-        "definition": "address",
-        "description": "the address of your workplace",
-        "destination": {
-          "path": "/tmp/address.adr"
-        }
-      },
       "email": {
         "definition": "email-address",
         "destination": {
@@ -658,6 +652,13 @@ Check out the [JSON Schema specification](https://json-schema.org/) for more exa
         "definition": "jpeg",
         "destination": {
           "path": "/tmp/user.jpg"
+        }
+      },
+      "workplace_address": {
+        "definition": "address",
+        "description": "the address of your workplace",
+        "destination": {
+          "path": "/tmp/address.adr"
         }
       }
     }
@@ -724,18 +725,20 @@ What about parameters such as database passwords used by the application? Proper
 > Note that the CNAB specification does not mandate specific security implementations on storage of either parameters or credentials. CNAB Runtimes ought to consider that both parameters and credentials may contain secret data, and OUGHT to secure both parameter and credential data in ways appropriate to the underlying platform. It is recommended that credentials are not persisted between actions, and that parameters _are_ persisted between actions.
 
 ```json
-"credentials": {
-    "kubeconfig": {
-        "path": "/home/.kube/config"
+{
+  "credentials": {
+    "hostkey": {
+      "env": "HOST_KEY",
+      "path": "/etc/hostkey.txt"
     },
     "image_token": {
-        "required": true,
-        "env": "AZ_IMAGE_TOKEN"
+      "env": "AZ_IMAGE_TOKEN",
+      "required": true
     },
-    "hostkey": {
-        "path": "/etc/hostkey.txt",
-        "env": "HOST_KEY"
+    "kubeconfig": {
+      "path": "/home/.kube/config"
     }
+  }
 }
 ```
 
@@ -775,19 +778,21 @@ Every implementation of a CNAB tool MUST support three built-in actions:
 Implementations MAY support user-defined additional actions as well. Such actions are exposed via the `bundle` definition file. An action definition contains an action _name_ followed by a description of that action:
 
 ```json
-"actions": {
-    "io.cnab.status":{
-        "modifies": false,
-        "description": "retrieves the status of an installation"
+{
+  "actions": {
+    "io.cnab.dry-run": {
+      "description": "prints what install would do with the given parameters values",
+      "modifies": false,
+      "stateless": true
     },
-    "io.cnab.migrate":{
-        "modifies": false
+    "io.cnab.migrate": {
+      "modifies": false
     },
-    "io.cnab.dry-run":{
-        "modifies": false,
-        "stateless": true,
-        "description": "prints what install would do with the given parameters values"
+    "io.cnab.status": {
+      "description": "retrieves the status of an installation",
+      "modifies": false
     }
+  }
 }
 ```
 
@@ -822,15 +827,15 @@ The `custom` object is used as follows:
 
 ```json
 {
-    "custom": {
-        "com.example.duffle-bag": {
-            "icon": "https://example.com/icon.png",
-            "iconType": "PNG"
-        },
-        "com.example.backup-preferences": {
-            "frequency": "daily"
-        }
+  "custom": {
+    "com.example.backup-preferences": {
+      "frequency": "daily"
+    },
+    "com.example.duffle-bag": {
+      "icon": "https://example.com/icon.png",
+      "iconType": "PNG"
     }
+  }
 }
 ```
 
@@ -838,9 +843,9 @@ The format is:
 
 ```json
 {
-    "custom": {
-        "EXTENSION NAME": "ARBITRARY JSON DATA"
-    }
+  "custom": {
+    "EXTENSION NAME": "ARBITRARY JSON DATA"
+  }
 }
 ```
 

--- a/102-invocation-image.md
+++ b/102-invocation-image.md
@@ -30,16 +30,16 @@ The following exhibits the filesystem layout:
 ```yaml
 cnab/                  # REQUIRED top-level directory
 └── build/
-    │   └──Dockerfile​  # OPTIONAL
-└── app​                # REQUIRED
-    ├── run​            # REQUIRED: This is the main entrypoint, and MUST be executable
-    ├── charts​         # Example: Helm charts might go here
-    │   └── azure-voting-app​
-    │       ├── Chart.yaml​
-    │       ├── templates​​
+    │   └──Dockerfile           # OPTIONAL
+└── app                         # REQUIRED
+    ├── run                     # REQUIRED: This is the main entrypoint, and MUST be executable
+    ├── charts                  # Example: Helm charts might go here
+    │   └── azure-voting-app
+    │       ├── Chart.yaml
+    │       ├── templates
     │       │   └── ...
-    │       └── values.yaml​
-    └── sfmesh​         # Example: Service Fabric definitions might go here
+    │       └── values.yaml
+    └── sfmesh                  # Example: Service Fabric definitions might go here
         └── sfmesh-deploy.json
 ```
 
@@ -50,10 +50,10 @@ An invocation image MUST have a directory named `cnab` placed directly under the
 This `cnab` directory MAY have any of the following:
 
 - `build/`: A directory containing files used in the construction of this image
-    - `Dockerfile`: A valid Dockerfile used for constructing this image
-    - Files for the form `Dockerfile.$INFO`, where `$INFO` is a further specification of that Dockerfile (e.g. `Dockerfile.arm64`)
-    - `packer.json`: A valid Packer configuration file
-    - Other build-related files
+  - `Dockerfile`: A valid Dockerfile used for constructing this image
+  - Files for the form `Dockerfile.$INFO`, where `$INFO` is a further specification of that Dockerfile (e.g. `Dockerfile.arm64`)
+  - `packer.json`: A valid Packer configuration file
+  - Other build-related files
 - `README.txt` or `README.md`: A text file containing information about this bundle
 - `LICENSE`: A text file containing the license(s) for this image
 
@@ -70,8 +70,8 @@ The contents beneath `/cnab/app/SUBDIRECTORY` are undefined by the spec. `run` i
 The directory `/cnab/build` MAY be present within the CNAB hierarchy. This directory houses files used in the construction of the invocation image, and are provided to make it easier to rebuild the image during rewrite operations. If a `Dockerfile` was used to build the image, a `Dockerfile` SHOULD be included. Other files MAY be included.
 
 Examples:
-    - `packer.json`
-    - `Dockerfile.arm32`
+- `packer.json`
+- `Dockerfile.arm32`
 
 #### Dockerfiles for Constructing Invocation Images
 

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -219,10 +219,10 @@ For this example CNAB bundle:
   "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
   "images": {
     "my-microservice": {
+      "contentDigest": "sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
       "description": "my microservice",
       "image": "technosophos/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
-      "originalImage": "gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
-      "contentDigest": "sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687"
+      "originalImage": "gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687"
     }
   },
   "invocationImages": [
@@ -260,12 +260,12 @@ The `/cnab/app/image-map.json` file mounted in the invocation image will be:
 
 ```json
 {
-    "my-microservice": {
-        "description": "my microservice",
-        "image": "technosophos/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
-        "originalImage": "gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
-        "contentDigest": "sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687"
-    }
+  "my-microservice": {
+    "contentDigest": "sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
+    "description": "my microservice",
+    "image": "technosophos/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
+    "originalImage": "gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687"
+  }
 }
 ```
 

--- a/400-claims.md
+++ b/400-claims.md
@@ -56,31 +56,31 @@ The CNAB claim is defined as a JSON document. The specification currently does n
 
 ```json
 {
+  "bundle": {
+    "credentials": {},
+    "images": {},
+    "invocationImages": [
+      {
+        "image": "technosophos/demo2:0.2.0",
+        "imageType": "docker"
+      }
+    ],
     "name": "technosophos.hellohelm",
-    "revision": "01CP6XM0KVB9V1BQDZ9NK8VP29",
-    "created": "2018-08-30T20:39:55.549002887-06:00",
-    "modified": "2018-08-30T20:39:59.611068556-06:00",
-    "bundle": {
-      "schemaVersion": "v1.0.0-WD",
-      "name": "technosophos.hellohelm",
-      "version": "0.1.0",
-      "invocationImages": [
-        {
-          "imageType": "docker",
-          "image": "technosophos/demo2:0.2.0"
-        }
-      ],
-      "images": {},
-      "parameters": {},
-      "credentials": {}
-    },
-    "result": {
-      "message": "",
-      "action": "install",
-      "status": "success"
-    },
-    "parameters": {}
-  }
+    "parameters": {},
+    "schemaVersion": "v1.0.0-WD",
+    "version": "0.1.0"
+  },
+  "created": "2018-08-30T20:39:55.549002887-06:00",
+  "modified": "2018-08-30T20:39:59.611068556-06:00",
+  "name": "technosophos.hellohelm",
+  "parameters": {},
+  "result": {
+    "action": "install",
+    "message": "",
+    "status": "success"
+  },
+  "revision": "01CP6XM0KVB9V1BQDZ9NK8VP29"
+}
 ```
 
 - name: The name of the _installation_. This can be automatically generated, though humans may need to interact with it. It MUST be unique within the installation environment, though that constraint MUST be imposed externally. Elsewhere, this field is referenced as the _installation name_.
@@ -172,20 +172,20 @@ If both commands exit with code `0`, then the resulting claim will look like thi
 
 ```json
 {
-    "name": "technosophos.my_first_install",
-    "revision": "01CN530TF9Q095VTRYP1M8797C",
-    "bundle": {
-        "uri": "hub.docker.com/technosophos/example_cnab",
-        "name": "technosophos.example_cnab",
-        "version": "0.1.0"
-    },
-    "created": "TIMESTAMP",
-    "modified": "TIMESTAMP",
-    "result": {
-        "message": "yay!",    // From STDOUT (echo)
-        "action": "install",  // Determined by the action
-        "status": "success"   // if exit code == 0, success, else failure
-    }
+  "bundle": {
+    "name": "technosophos.example_cnab",
+    "uri": "hub.docker.com/technosophos/example_cnab",
+    "version": "0.1.0"
+  },
+  "created": "TIMESTAMP",
+  "modified": "TIMESTAMP",
+  "name": "technosophos.my_first_install",
+  "result": {
+    "message": "yay!",    // From STDOUT (echo)
+    "action": "install",  // Determined by the action
+    "status": "success"   // if exit code == 0, success, else failure
+  },
+  "revision": "01CN530TF9Q095VTRYP1M8797C"
 }
 ```
 

--- a/500-CNAB-dependencies.md
+++ b/500-CNAB-dependencies.md
@@ -15,13 +15,13 @@ This specification, the CNAB Dependencies specification, is not part of the CNAB
 
 One way for a bundle author to manage the complexity of a large bundle and reuse
 common logic is to create bundles for discrete components, such as managing
-a database as a service on a cloud platform, and then use that bundle as a 
+a database as a service on a cloud platform, and then use that bundle as a
 dependency.
 
-This specification defines [dependencies metadata](#dependencies-metadata) in the 
+This specification defines [dependencies metadata](#dependencies-metadata) in the
 bundle.json for specifying dependencies but does not dictate that the metadata is
-specifically used at a particular time, or how the dependency graph is resolved. 
-Each tool may choose to use the information differently, for example [porter](https://porter.sh) resolves dependencies when the bundle is built, but another tool could 
+specifically used at a particular time, or how the dependency graph is resolved.
+Each tool may choose to use the information differently, for example [porter](https://porter.sh) resolves dependencies when the bundle is built, but another tool could
 use this information at runtime.
 
 There are two cases for how a bundle may need to depend upon another bundle:
@@ -35,18 +35,18 @@ The bundle depends on a specific named bundle that is known in advance.
 
 ```json
 {
-    "name": "wordpress",
-    "dependencies": [
-        {
-            "requires":{
-                "bundle": "azure/mysql",
-                "version": {
-                    "range": "5.7.x",
-                    "prereleases": "true"
-                }
-            }
+  "dependencies": [
+    {
+      "requires": {
+        "bundle": "azure/mysql",
+        "version": {
+          "prereleases": "true",
+          "range": "5.7.x"
         }
-    ]
+      }
+    }
+  ],
+  "name": "wordpress"
 }
 ```
 
@@ -66,12 +66,12 @@ The `requires` object defines the criteria for the dependent bundle:
 * `bundle`: A reference to a bundle in the format REGISTRY/NAME.
 * `version`: A set of criteria applied to the bundle version when selecting an
     acceptable version of the bundle.
-    * `ranges`: An array of allowed version ranges. 
-    
-        Versions are specified using semver, with or without a leading "v". 
-        An `x` in the place of the minor or patch place can be used to specify 
-        a wildcard. Ranges can be specified by separating the two versions with 
-        a dash, the dash must be surrounded by spaces in order to disambiguate 
+    * `ranges`: An array of allowed version ranges.
+
+        Versions are specified using semver, with or without a leading "v".
+        An `x` in the place of the minor or patch place can be used to specify
+        a wildcard. Ranges can be specified by separating the two versions with
+        a dash, the dash must be surrounded by spaces in order to disambiguate
         from prerelease tags.
 
         Below are some example ranges:

--- a/802-credential-sets.md
+++ b/802-credential-sets.md
@@ -13,18 +13,18 @@ In the bundle descriptor, credentials are declared like this:
 
 ```json
 {
-    "credentials": {
-        "kubeconfig": {
-            "path": "/home/.kube/config",
-        },
-        "image_token": {
-            "env": "AZ_IMAGE_TOKEN",
-        },
-        "hostkey": {
-            "path": "/etc/hostkey.txt",
-            "env": "HOST_KEY"
-        }
+  "credentials": {
+    "hostkey": {
+      "env": "HOST_KEY",
+      "path": "/etc/hostkey.txt"
+    },
+    "image_token": {
+      "env": "AZ_IMAGE_TOKEN"
+    },
+    "kubeconfig": {
+      "path": "/home/.kube/config"
     }
+  }
 }
 ```
 

--- a/804-well-known-custom-actions.md
+++ b/804-well-known-custom-actions.md
@@ -16,17 +16,17 @@ A CNAB indicates that it supports those actions by including them in its custom 
 
 ```json
 {
-    "status": "Failed",
-    "message": "Component front-end failed to deploy properly",
-    "components":{
-        "backend": {
-            "status": "Ready"
-        },
-        "front-end": {
-            "status": "Failed",
-            "message": "Failed to pull Docker image mginx:latest",
-        },
+  "components": {
+    "backend": {
+      "status": "Ready"
+    },
+    "front-end": {
+      "message": "Failed to pull Docker image mginx:latest",
+      "status": "Failed"
     }
+  },
+  "message": "Component front-end failed to deploy properly",
+  "status": "Failed"
 }
 ```
   - `status` is a value indicating the deployment status of a component or of the whole bundle. Well known values are `Failed`, `Ready`, `Pending`. An invocation image MAY use other custom-values, but tools must at least understand those values.
@@ -34,54 +34,53 @@ A CNAB indicates that it supports those actions by including them in its custom 
   - `components`: map of components/statuses allowing a more detailed status. A component can itself have subcomponent, to enable scenarios like aggregating statuses in CNABs composed of other CNABs. e.g.:
 ```json
 {
-    "status": "Ready",
-    "components": {
-        "gke": {
-            "status" : "Ready",
-            "components": {
-                "kube-api": {
-                    "status": "Ready"
-                },
-                "network": {
-                    "status": "Ready"
-                },
-                "scheduler": {
-                    "status": "Ready"
-                }
-            }
+  "components": {
+    "gke": {
+      "components": {
+        "kube-api": {
+          "status": "Ready"
         },
-        "wordpress": {
-            "status": "Ready"
+        "network": {
+          "status": "Ready"
+        },
+        "scheduler": {
+          "status": "Ready"
         }
+      },
+      "status": "Ready"
+    },
+    "wordpress": {
+      "status": "Ready"
     }
+  },
+  "status": "Ready"
 }
 ```
   - Additionaly to the fields defined above, an invocation image MAY add custom fields as they want. To avoid ambiguous naming, those fields names MAY be namespaced. An example of that could be a CNAB bundle deploying Kubernetes workloads and exposing scale details:
 ```json
 {
-    "status": "Pending",
-    "components":{
-        "backend": {
-            "status": "Ready",
-            "com.example.scale": {
-                "desired": 3,
-                "actual": 3,
-                "failed": 0,
-                "pending": 0
-            }
-        },
-        "front-end": {
-            "status": "Pending",
-            "com.example.scale": {
-                "desired": 3,
-                "actual": 2,
-                "failed": 0,
-                "pending": 1
-            }
-        },
+  "components": {
+    "backend": {
+      "com.example.scale": {
+        "actual": 3,
+        "desired": 3,
+        "failed": 0,
+        "pending": 0
+      },
+      "status": "Ready"
+    },
+    "front-end": {
+      "com.example.scale": {
+        "actual": 2,
+        "desired": 3,
+        "failed": 0,
+        "pending": 1
+      },
+      "status": "Pending"
     }
+  },
+  "status": "Pending"
 }
 ```
-
 
 Next section: [Standardization Process](901-process.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ In addition, by making a contribution to specifications in this repository, you,
 Final specifications developed in this repository will be subject to the [Open Web Foundation Final Specification Agreement (“OWFa 1.0”)](http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-00).  OWFa 1.0 will be applied as follows:
 -	The maintainer will notify all contributors to a designated specification in writing via provided contact information of the start of a 30 day review period, after which the specification will be subject to the OWFa 1.0.
 -	During that 30 day period, contributors may provide written notice to the maintainer that the contributor is not making the forgoing commitment under OWFa 1.0 for the designated specification (“Exclusion”).
--	Upon the end of that 30 day notice period, those contributors who have not issued an Exclusion, on behalf of themselves, their employer, and its affiliates, will, without further action, be subject to the obligations set forth in the OWFa 1.0 for the designated specification.  
+-	Upon the end of that 30 day notice period, those contributors who have not issued an Exclusion, on behalf of themselves, their employer, and its affiliates, will, without further action, be subject to the obligations set forth in the OWFa 1.0 for the designated specification.
 
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/examples/103.1-bundle.json
+++ b/examples/103.1-bundle.json
@@ -22,10 +22,10 @@
   "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
   "images": {
     "my-microservice": {
+      "contentDigest": "sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
       "description": "my microservice",
       "image": "technosophos/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
-      "originalImage": "gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
-      "contentDigest": "sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687"
+      "originalImage": "gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687"
     }
   },
   "invocationImages": [

--- a/examples/400.01-claim.json
+++ b/examples/400.01-claim.json
@@ -1,26 +1,26 @@
 {
+  "bundle": {
+    "credentials": {},
+    "images": {},
+    "invocationImages": [
+      {
+        "image": "technosophos/demo2:0.2.0",
+        "imageType": "docker"
+      }
+    ],
     "name": "technosophos.hellohelm",
-    "revision": "01CP6XM0KVB9V1BQDZ9NK8VP29",
-    "created": "2018-08-30T20:39:55.549002887-06:00",
-    "modified": "2018-08-30T20:39:59.611068556-06:00",
-    "bundle": {
-      "schemaVersion": "v1.0.0-WD",
-      "name": "technosophos.hellohelm",
-      "version": "0.1.0",
-      "invocationImages": [
-        {
-          "imageType": "docker",
-          "image": "technosophos/demo2:0.2.0"
-        }
-      ],
-      "images": {},
-      "parameters": {},
-      "credentials": {}
-    },
-    "result": {
-      "message": "",
-      "action": "install",
-      "status": "success"
-    },
-    "parameters": {}
-  }
+    "parameters": {},
+    "schemaVersion": "v1.0.0-WD",
+    "version": "0.1.0"
+  },
+  "created": "2018-08-30T20:39:55.549002887-06:00",
+  "modified": "2018-08-30T20:39:59.611068556-06:00",
+  "name": "technosophos.hellohelm",
+  "parameters": {},
+  "result": {
+    "action": "install",
+    "message": "",
+    "status": "success"
+  },
+  "revision": "01CP6XM0KVB9V1BQDZ9NK8VP29"
+}

--- a/examples/805.01-status.json
+++ b/examples/805.01-status.json
@@ -1,10 +1,10 @@
 {
-    "status": "Ready",
-    "message": "All systems go",
-    "components":{
-      "web": {
-        "status": "Ready",
-        "message": "Listening on port :8080"
-      }
+  "components": {
+    "web": {
+      "message": "Listening on port :8080",
+      "status": "Ready"
     }
-  }
+  },
+  "message": "All systems go",
+  "status": "Ready"
+}

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -1,318 +1,341 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://cnab.io/v1/bundle.schema.json",
-    "title": "CNAB1 Bundle Descriptor",
-    "description": "Cloud Native Application - Core version 1 - Bundle Descriptor",
-    "type": "object",
-    "properties": {
-        "schemaVersion": {
-            "description": "The version of the CNAB specification. This should always be the string 'v1' for this schema version.",
-            "type": "string"
+  "$id": "http://cnab.io/v1/bundle.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "credential": {
+      "description": "Credential defines a particular credential, and where it should be placed in the invocation image",
+      "properties": {
+        "description": {
+          "description": "A user-friendly description of this credential",
+          "type": "string"
         },
-        "name":{
-            "description": "The name of this bundle",
-            "type": "string"
+        "env": {
+          "description": "The environment variable name, such as MY_VALUE, into which the credential will be placed",
+          "type": "string"
         },
-        "version":{
-            "description": "A SemVer2 version for this bundle",
-            "type": "string",
-            "pattern": "v?([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?"
+        "path": {
+          "description": "The path inside of the invocation image where credentials will be mounted",
+          "pattern": "^(?!/cnab/app/outputs)/.+$",
+          "type": "string"
         },
-        "description":{
-            "description": "A description of this bundle, intended for users",
-            "type": "string"
-        },
-        "keywords":{
-            "description": "A list of keywords describing the bundle, intended for users",
-            "type": "array",
-            "items": {
-                "type": "string"
-            }
-        },
-        "maintainers":{
-            "description": "A list of parties responsible for this bundle, with contact info",
-            "type": "array",
-            "items": {
-                "description": "An object that describes a maintainer",
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "description": "Name of party reponsible for this bundle",
-                        "type": "string"
-                    },
-                    "email":{
-                        "description": "Email address of responsible party",
-                        "type": "string"
-                    },
-                    "url":{
-                        "description": "URL of the responsible party, perhaps containing additional contact info",
-                        "type": "string"
-                    }
-                },
-                "required": ["name"]
-            }
-        },
-        "license":{
-            "description": "The SPDX license code or proprietary license name for this bundle",
-            "type": "string"
-        },
-        "invocationImages":{
-            "description": "The array of invocation image definitions for this bundle",
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/invocationImage"
-            }
-        },
-        "images":{
-            "description": "Images that are used by this bundle",
-            "type": "object",
-            "additionalProperties": {
-                "$ref": "#/definitions/image"
-            }
-        },
-        "credentials":{
-            "description":"Credentials to be injected into the invocation image",
-            "type": "object",
-            "additionalProperties": {
-                "$ref": "#/definitions/credential"
-            }
-        },
-        "actions":{
-            "description": "Custom actions that can be triggered on this bundle, action name should be namespaced and use reverse DNS notation",
-            "type": "object",
-            "additionalProperties": {
-                "type": "object",
-                "properties": {
-                    "modifies": {
-                        "description": "Must be set to true if the action can change any resource managed by this bundle",
-                        "type": "boolean"
-                    },
-                    "description": {
-                        "description": "A description of the purpose of this action",
-                        "type": "string"
-                    },
-                    "stateless":{
-                        "description": "Indicates that the action is purely informational, that credentials are not required, and that the runtime should not keep track of its invocation",
-                        "type": "boolean",
-                        "default": "false"
-                    }
-                }
-            }
-        },
-        "custom":{
-            "$comment": "reserved for custom extensions"
-        },
-        "definitions": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "http://json-schema.org/draft-07/schema#"
-          }
-        },
-        "parameters":{
-            "description": "Parameters that can be injected into the invocation image",
-            "type": "object",
-            "properties": {
-                "fields" : {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref":  "#/definitions/parameter"
-                    }
-                },
-                "required": { "$ref": "http://json-schema.org/draft-07/schema#/properties/required" }
-            }
-        },
-        "outputs":{
-            "description": "Values that are produced by executing the invocation image",
-            "type": "object",
-            "properties": {
-                "fields": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref":  "#/definitions/output"
-                    }
-                }
-            }
+        "required": {
+          "default": false,
+          "description": "Indicates whether this credential must be supplied. By default, credentials are optional.",
+          "type": "boolean"
         }
+      },
+      "type": "object"
     },
-    "required": [ "name", "version", "invocationImages", "schemaVersion"],
-    "definitions": {
-        "invocationImage": {
-            "description": "A bootstrapping image for the CNAB bundle.",
-            "type": "object",
-            "properties": {
-                "image":{
-                    "description": "A resolvable reference to the image. This may be interpreted differently based on imageType, but the default is to treat this as an OCI image",
-                    "type": "string"
-                },
-                "originalImage":{
-                    "description": "A resolvable reference to the original image. This may be interpreted differently based on imageType, but the default is to treat this as an OCI image. If this is not specified, the value is assumed to be that of the image field",
-                    "type": "string"
-                },
-                "imageType":{
-                    "description": "The type of image. If this is not specified, 'oci' is assumed",
-                    "type": "string",
-                    "default": "oci"
-                },
-                "contentDigest":{
-                    "description": "A cryptographic hash digest of the contents of the image that can be used to validate the image. This may be interpreted differently based on imageType",
-                    "type": "string"
-                },
-                "size": {
-                    "description": "The image size in bytes",
-                    "type":"integer"
-                },
-                "platform":{
-                    "description": "The target platform",
-                    "type": "object",
-                    "properties": {
-                        "architecture": {
-                            "description": "The architecture of the image (i386, amd64, arm32, arm64,...)",
-                            "type": "string"
-                        },
-                        "os": {
-                            "description": "The operating system of the image (linux, windows, darwin,...)",
-                            "type": "string"
-                        }
-                    }
-                },
-                "mediaType":{
-                    "description": "The media type of the image",
-                    "type": "string"
-                }
-            },
-            "required": ["image"]
+    "image": {
+      "description": "An application image for this CNAB bundle",
+      "properties": {
+        "contentDigest": {
+          "description": "A cryptographic hash digest of the contents of the image that can be used to validate the image. This may be interpreted differently based on imageType",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the purpose of this image",
+          "type": "string"
         },
         "image": {
-            "description": "An application image for this CNAB bundle",
-            "type": "object",
-            "properties": {
-                "description": {
-                    "description": "A description of the purpose of this image",
-                    "type": "string"
-                },
-                "image":{
-                    "description": "A resolvable reference to the image. This may be interpreted differently based on imageType, but the default is to treat this as an OCI image",
-                    "type": "string"
-                },
-                "originalImage":{
-                    "description": "A resolvable reference to the image. This may be interpreted differently based on imageType, but the default is to treat this as an OCI image. If this is not specified, the value is assumed to be that of the image field",
-                    "type": "string"
-                },
-                "imageType":{
-                    "description": "The type of image. If this is not specified, 'oci' is assumed",
-                    "type": "string",
-                    "default": "oci"
-                },
-                "contentDigest":{
-                    "description": "A cryptographic hash digest of the contents of the image that can be used to validate the image. This may be interpreted differently based on imageType",
-                    "type": "string"
-                },
-                "size": {
-                    "description": "The image size in bytes",
-                    "type":"integer"
-                },
-                "platform":{
-                    "description": "The target platform",
-                    "type": "object",
-                    "properties": {
-                        "architecture": {
-                            "description": "The architecture of the image (i386, amd64, arm32, arm64,...)",
-                            "type": "string"
-                        },
-                        "os": {
-                            "description": "The operating system of the image (linux, windows, darwin,...)",
-                            "type": "string"
-                        }
-                    }
-                },
-                "mediaType":{
-                    "description": "The media type of the image",
-                    "type": "string"
-                }
-            },
-            "required": ["image"]
+          "description": "A resolvable reference to the image. This may be interpreted differently based on imageType, but the default is to treat this as an OCI image",
+          "type": "string"
         },
-        "credential": {
-            "description": "Credential defines a particular credential, and where it should be placed in the invocation image",
-            "type": "object",
-            "properties": {
-                "path":{
-                    "description": "The path inside of the invocation image where credentials will be mounted",
-                    "type": "string",
-                    "pattern": "^(?!\/cnab\/app\/outputs)\/.+$"
-                },
-                "env":{
-                    "description": "The environment variable name, such as MY_VALUE, into which the credential will be placed",
-                    "type": "string"
-                },
-                "description": {
-                    "description": "A user-friendly description of this credential",
-                    "type": "string"
-                },
-                "required": {
-                    "description": "Indicates whether this credential must be supplied. By default, credentials are optional.",
-                    "type": "boolean",
-                    "default": false
-                }
+        "imageType": {
+          "default": "oci",
+          "description": "The type of image. If this is not specified, 'oci' is assumed",
+          "type": "string"
+        },
+        "mediaType": {
+          "description": "The media type of the image",
+          "type": "string"
+        },
+        "originalImage": {
+          "description": "A resolvable reference to the image. This may be interpreted differently based on imageType, but the default is to treat this as an OCI image. If this is not specified, the value is assumed to be that of the image field",
+          "type": "string"
+        },
+        "platform": {
+          "description": "The target platform",
+          "properties": {
+            "architecture": {
+              "description": "The architecture of the image (i386, amd64, arm32, arm64,...)",
+              "type": "string"
+            },
+            "os": {
+              "description": "The operating system of the image (linux, windows, darwin,...)",
+              "type": "string"
             }
+          },
+          "type": "object"
         },
-        "parameter": {
-            "description": "A parameter that can be passed into the invocation image",
-            "type": "object",
-            "properties": {
-                "definition": {
-                  "type": "string",
-                  "description": "The name of a definition that describes the schema structure of this parameter"
-                },
-                "description": { "$ref": "http://json-schema.org/draft-07/schema#/properties/description" },
-                "destination": {
-                    "type": "object",
-                    "properties": {
-                        "path":{
-                            "description": "The path inside of the invocation image where parameter data is mounted",
-                            "type": "string",
-                            "pattern": "^(?!\/cnab\/app\/outputs)\/.+$"
-                        },
-                        "env":{
-                            "description": "The environment variable name, such as MY_VALUE, in which the parameter value is stored",
-                            "type": "string"
-                        }
-                    }
-                },
-                "applyTo":{
-                    "description": "An optional exhaustive list of actions handling this parameter",
-                    "type":"array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            },
-            "required": ["definition", "destination"]
-        },
-        "output": {
-            "description": "A value that is produced by running an invocation image",
-            "type": "object",
-            "properties": {
-                "applyTo":{
-                    "description": "An optional exhaustive list of actions producing this output",
-                    "type":"array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "definition": {
-                  "type": "string",
-                  "description": "The name of a definition that describes the schema structure of this output"
-                },
-                "description": { "$ref": "http://json-schema.org/draft-07/schema#/properties/description" },
-                "path":{
-                    "description": "The path inside of the invocation image where output will be written",
-                    "type": "string",
-                    "pattern": "^\/cnab\/app\/outputs\/.+$"
-                }
-            },
-            "required": ["definition", "path"]
+        "size": {
+          "description": "The image size in bytes",
+          "type": "integer"
         }
+      },
+      "required": [
+        "image"
+      ],
+      "type": "object"
     },
-    "additionalProperties": false
+    "invocationImage": {
+      "description": "A bootstrapping image for the CNAB bundle.",
+      "properties": {
+        "contentDigest": {
+          "description": "A cryptographic hash digest of the contents of the image that can be used to validate the image. This may be interpreted differently based on imageType",
+          "type": "string"
+        },
+        "image": {
+          "description": "A resolvable reference to the image. This may be interpreted differently based on imageType, but the default is to treat this as an OCI image",
+          "type": "string"
+        },
+        "imageType": {
+          "default": "oci",
+          "description": "The type of image. If this is not specified, 'oci' is assumed",
+          "type": "string"
+        },
+        "mediaType": {
+          "description": "The media type of the image",
+          "type": "string"
+        },
+        "originalImage": {
+          "description": "A resolvable reference to the original image. This may be interpreted differently based on imageType, but the default is to treat this as an OCI image. If this is not specified, the value is assumed to be that of the image field",
+          "type": "string"
+        },
+        "platform": {
+          "description": "The target platform",
+          "properties": {
+            "architecture": {
+              "description": "The architecture of the image (i386, amd64, arm32, arm64,...)",
+              "type": "string"
+            },
+            "os": {
+              "description": "The operating system of the image (linux, windows, darwin,...)",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "size": {
+          "description": "The image size in bytes",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "type": "object"
+    },
+    "output": {
+      "description": "A value that is produced by running an invocation image",
+      "properties": {
+        "applyTo": {
+          "description": "An optional exhaustive list of actions producing this output",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "definition": {
+          "description": "The name of a definition that describes the schema structure of this output",
+          "type": "string"
+        },
+        "description": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+        },
+        "path": {
+          "description": "The path inside of the invocation image where output will be written",
+          "pattern": "^/cnab/app/outputs/.+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "definition",
+        "path"
+      ],
+      "type": "object"
+    },
+    "parameter": {
+      "description": "A parameter that can be passed into the invocation image",
+      "properties": {
+        "applyTo": {
+          "description": "An optional exhaustive list of actions handling this parameter",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "definition": {
+          "description": "The name of a definition that describes the schema structure of this parameter",
+          "type": "string"
+        },
+        "description": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+        },
+        "destination": {
+          "properties": {
+            "env": {
+              "description": "The environment variable name, such as MY_VALUE, in which the parameter value is stored",
+              "type": "string"
+            },
+            "path": {
+              "description": "The path inside of the invocation image where parameter data is mounted",
+              "pattern": "^(?!/cnab/app/outputs)/.+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "definition",
+        "destination"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "Cloud Native Application - Core version 1 - Bundle Descriptor",
+  "properties": {
+    "actions": {
+      "additionalProperties": {
+        "properties": {
+          "description": {
+            "description": "A description of the purpose of this action",
+            "type": "string"
+          },
+          "modifies": {
+            "description": "Must be set to true if the action can change any resource managed by this bundle",
+            "type": "boolean"
+          },
+          "stateless": {
+            "default": "false",
+            "description": "Indicates that the action is purely informational, that credentials are not required, and that the runtime should not keep track of its invocation",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "description": "Custom actions that can be triggered on this bundle, action name should be namespaced and use reverse DNS notation",
+      "type": "object"
+    },
+    "credentials": {
+      "additionalProperties": {
+        "$ref": "#/definitions/credential"
+      },
+      "description": "Credentials to be injected into the invocation image",
+      "type": "object"
+    },
+    "custom": {
+      "$comment": "reserved for custom extensions"
+    },
+    "definitions": {
+      "additionalProperties": {
+        "$ref": "http://json-schema.org/draft-07/schema#"
+      },
+      "type": "object"
+    },
+    "description": {
+      "description": "A description of this bundle, intended for users",
+      "type": "string"
+    },
+    "images": {
+      "additionalProperties": {
+        "$ref": "#/definitions/image"
+      },
+      "description": "Images that are used by this bundle",
+      "type": "object"
+    },
+    "invocationImages": {
+      "description": "The array of invocation image definitions for this bundle",
+      "items": {
+        "$ref": "#/definitions/invocationImage"
+      },
+      "type": "array"
+    },
+    "keywords": {
+      "description": "A list of keywords describing the bundle, intended for users",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "license": {
+      "description": "The SPDX license code or proprietary license name for this bundle",
+      "type": "string"
+    },
+    "maintainers": {
+      "description": "A list of parties responsible for this bundle, with contact info",
+      "items": {
+        "description": "An object that describes a maintainer",
+        "properties": {
+          "email": {
+            "description": "Email address of responsible party",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of party reponsible for this bundle",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the responsible party, perhaps containing additional contact info",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "name": {
+      "description": "The name of this bundle",
+      "type": "string"
+    },
+    "outputs": {
+      "description": "Values that are produced by executing the invocation image",
+      "properties": {
+        "fields": {
+          "additionalProperties": {
+            "$ref": "#/definitions/output"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "parameters": {
+      "description": "Parameters that can be injected into the invocation image",
+      "properties": {
+        "fields": {
+          "additionalProperties": {
+            "$ref": "#/definitions/parameter"
+          },
+          "type": "object"
+        },
+        "required": {
+          "$ref": "http://json-schema.org/draft-07/schema#/properties/required"
+        }
+      },
+      "type": "object"
+    },
+    "schemaVersion": {
+      "description": "The version of the CNAB specification. This should always be the string 'v1' for this schema version.",
+      "type": "string"
+    },
+    "version": {
+      "description": "A SemVer2 version for this bundle",
+      "pattern": "v?([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?",
+      "type": "string"
+    }
+  },
+  "required": [
+    "invocationImages",
+    "name",
+    "schemaVersion",
+    "version"
+  ],
+  "title": "CNAB1 Bundle Descriptor",
+  "type": "object"
 }

--- a/schema/claim.schema.json
+++ b/schema/claim.schema.json
@@ -1,63 +1,77 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://cnab.io/v1/claims.schema.json",
-    "title": "CNAB Claims json schema",
-    "type": "object",
-    "properties": {
-        "name": {
-            "type": "string",
-            "description": "the name of the installation"
+  "$id": "http://cnab.io/v1/claims.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "result": {
+      "properties": {
+        "action": {
+          "description": "the name of the action. One of the built-ins (install, uninstall, upgrade) or a custom action.",
+          "type": "string"
         },
-        "revision": {
-            "type": "string",
-            "description": "the revision ID (ideally a ULID)"
+        "message": {
+          "description": "the last message from the invocation image or runtime",
+          "type": "string"
         },
-        "created": {
-            "type": "string",
-            "description": "The date created, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard"
-        },
-        "modified": {
-            "type": "string",
-            "description": "The date last modified, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard"
-        },
-        "bundle":{
-            "description": "The bundle descriptor",
-            "$ref": "http://cnab.io/v1/bundle.schema.json"
-        },
-        "result": {
-            "description": "The result of the last action",
-            "$ref": "#/definitions/result"
-
-        },
-        "parameters": {
-            "type": "object",
-            "description": "key/value pairs of parameter name to parameter value."
-        },
-        "custom": {
-            "$comment": "reserved for custom extensions"
-        },
-        "additionalProperties": false
-    },
-    "required": ["name", "revision", "created", "modified", "bundle"],
-    "definitions": {       
-        "result": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string",
-                    "description": "the last message from the invocation image or runtime"
-                },
-                "action": {
-                    "type": "string",
-                    "description": "the name of the action. One of the built-ins (install, uninstall, upgrade) or a custom action."
-                },
-                "status": {
-                    "type": "string",
-                    "descripton": "The status of the last action",
-                    "enum": ["success", "failure", "underay", "unknown"]
-                }
-            },
-            "required": ["action", "message", "status"]
+        "status": {
+          "descripton": "The status of the last action",
+          "enum": [
+            "failure",
+            "success",
+            "underay",
+            "unknown"
+          ],
+          "type": "string"
         }
+      },
+      "required": [
+        "action",
+        "message",
+        "status"
+      ],
+      "type": "object"
     }
+  },
+  "properties": {
+    "additionalProperties": false,
+    "bundle": {
+      "$ref": "http://cnab.io/v1/bundle.schema.json",
+      "description": "The bundle descriptor"
+    },
+    "created": {
+      "description": "The date created, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
+      "type": "string"
+    },
+    "custom": {
+      "$comment": "reserved for custom extensions"
+    },
+    "modified": {
+      "description": "The date last modified, as an ISO-8601 Extended Format date string, as specified in the ECMAScript standard",
+      "type": "string"
+    },
+    "name": {
+      "description": "the name of the installation",
+      "type": "string"
+    },
+    "parameters": {
+      "description": "key/value pairs of parameter name to parameter value.",
+      "type": "object"
+    },
+    "result": {
+      "$ref": "#/definitions/result",
+      "description": "The result of the last action"
+    },
+    "revision": {
+      "description": "the revision ID (ideally a ULID)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "bundle",
+    "created",
+    "modified",
+    "name",
+    "revision"
+  ],
+  "title": "CNAB Claims json schema",
+  "type": "object"
 }

--- a/schema/status.schema.json
+++ b/schema/status.schema.json
@@ -1,45 +1,45 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://cnab.io/v1/status.schema.json",
-    "title": "CNAB Status json schema",
-    "type": "object",
-    "properties": {
-        "status": {
-            "type": "string",
-            "description": "string identifying the status of a component (Ready, Pending, Failed are well known values)"
+  "$id": "http://cnab.io/v1/status.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "component": {
+      "properties": {
+        "additionalProperties": true,
+        "components": {
+          "additionalProperties": {
+            "$ref": "#"
+          },
+          "type": "object"
         },
         "message": {
-            "type": "string",
-            "description": "details about the current status"
+          "description": "details about the current status",
+          "type": "string"
         },
-        "components": {
-            "type":"object",
-            "additionalProperties": {
-                "$ref": "#/definitions/component"
-            }	            
-        },
-        "additionalProperties": true
-    },
-    "definitions": {
-        "component":{
-            "type":"object",
-            "properties": {
-                "status": {
-                    "type": "string",
-                    "description": "string identifying the status of a component (Ready, Pending, Failed are well known values)"
-                },
-                "message": {
-                    "type": "string",
-                    "description": "details about the current status"
-                },
-                "components": {
-                    "type":"object",
-                    "additionalProperties": {
-                        "$ref": "#"
-                    }	            
-                },
-                "additionalProperties": true
-            }
+        "status": {
+          "description": "string identifying the status of a component (Ready, Pending, Failed are well known values)",
+          "type": "string"
         }
+      },
+      "type": "object"
     }
+  },
+  "properties": {
+    "additionalProperties": true,
+    "components": {
+      "additionalProperties": {
+        "$ref": "#/definitions/component"
+      },
+      "type": "object"
+    },
+    "message": {
+      "description": "details about the current status",
+      "type": "string"
+    },
+    "status": {
+      "description": "string identifying the status of a component (Ready, Pending, Failed are well known values)",
+      "type": "string"
+    }
+  },
+  "title": "CNAB Status json schema",
+  "type": "object"
 }


### PR DESCRIPTION
Now that much of the large changes in 1.0 have landed, I went through and fixed a number of formatting and whitespace issues. The changes are to the formatting of JSON documents and the removal of extraneous whitespace. In the process, I discovered and resolved a few cases where we were showing examples of JSON snippets that were not valid JSON (extra trailing commas or missing closing brackets). 