### PR TITLE
add Jeremy as core maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,6 @@
 maintainers:
-- michelleN
 - radu-matei
 - simonferquel
 - technosophos
 - youreddy
+- jeremyrickard


### PR DESCRIPTION
Some of my priorities have changed and I haven't been as involved lately. I'd love to propose @jeremyrickard as core maintainer on the spec as a replacement for me. He has already been doing great work across the spec, porter and duffle and should have actually been on the core maintainer list when I originally committed it.