### PR TITLE
Add immutable flag to parameters.

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -233,7 +233,8 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
         "description": "The port that the backend will listen on",
         "destination": {
           "path": "/path/to/backend_port"
-        }
+        },
+        "immutable" : true
       }
     }
   },
@@ -480,6 +481,7 @@ Parameter specifications consist of name/value pairs. The name is fixed, but the
       - `destination`: Indicates where (in the invocation image) the parameter is to be written (REQUIRED)
         - `env`: The name of an environment variable
         - `path`: The fully qualified path to a file that will be created. Specified path MUST NOT be a subpath of `/cnab/app/outputs`.
+      - `immutable`: an immutable parameter may only be set at installation. The value of the parameter cannot be changed. MUST be a boolean. Default value is false. (OPTIONAL).
   - `required`: A list of required parameters. MUST be an array of strings.(OPTIONAL)
 
 Parameter names (the keys in `fields`) ought to conform to the [Open Group Base Specification Issue 6, Section 8.1, paragraph 4](http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html) definition of environment variable names with one exception: parameter names MAY begin with a digit (approximately `[A-Z0-9_]+`).
@@ -559,7 +561,8 @@ The structure of a `parameters` and `definitions` section looks like the section
         "destination": {
           "env": <string>,
           "path": <string>
-        }
+        },
+        "immutable" : <boolean>
       }
     },
     "required": [ <string> ]

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -138,6 +138,7 @@ The parameter value is evaluated thus:
 - If the parameter is marked `required` and a value is not supplied, the CNAB Runtime MUST produce an error and discontinue action.
 - If the CNAB runtime does not provide a value, but `default` is set, then the default value MUST be used.
 - If no value is provided and `default` is unset, the runtime MUST set the value to an empty string (""), regardless of type.
+- If an immutable parameter value is specified at any time after _install_, the CNAB Runtime MUST produce an error and discontinue action.
 
 > Setting the value of other types to a default value based on type, e.g. Boolean to `false` or integer to `0`, is considered _incorrect behavior_. Setting the value to `null`, `nil`, or a related character string is also considered incorrect.
 

--- a/examples/101.02-bundle.json
+++ b/examples/101.02-bundle.json
@@ -88,7 +88,8 @@
         "description": "The port that the backend will listen on",
         "destination": {
           "path": "/path/to/backend_port"
-        }
+        },
+        "immutable" : true
       }
     }
   },

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -186,6 +186,11 @@
             }
           },
           "type": "object"
+        },
+        "immutable": {
+          "description": "A flag indicating if the parameter value can be changed once it is set",
+          "type" : "boolean",
+          "default": false
         }
       },
       "required": [


### PR DESCRIPTION
This PR adds an immutable flag to the parameter definition in `101-bundle-json.md` and adds wording to `103-bundle-runtime.md` to indicate that if an immutable parameter value is given at any time other than runtime, it should result in an error. 

Closes #181