### PR TITLE
Fix dependency example json

### DIFF
--- a/500-CNAB-dependencies.md
+++ b/500-CNAB-dependencies.md
@@ -38,18 +38,17 @@ stored in the custom extensions section of the bundle.
 {
   "custom": {
     "dependencies": {
-      "requires": [
-        {
+      "requires": {
+        "storage": {
           "bundle": "somecloud/blob-storage"
         },
-        {
+        "mysql": {
           "bundle": "somecloud/mysql",
           "version": {
             "prereleases": true,
             "ranges": ["5.7.x"]
           }
         }
-      ]
     },
   },
   "name": "wordpress"
@@ -67,7 +66,8 @@ that defines metadata necessary to specify a dependency.
 
 ### requires
 
-The `requires` array defines the criteria for the dependent bundle:
+The `requires` map defines the criteria for the dependent bundle. The key for
+each dependency is a way for the bundle to reference the dependency.
 
 * `bundle`: A reference to a bundle in the format REGISTRY/NAME.
 * `version`: A set of criteria applied to the bundle version when selecting an

--- a/500-CNAB-dependencies.md
+++ b/500-CNAB-dependencies.md
@@ -31,11 +31,13 @@ There are two cases for how a bundle may need to depend upon another bundle:
 
 ## Depend on a named bundle
 
-The bundle depends on a specific named bundle that is known in advance.
+The bundle depends on a specific named bundle that is known in advance. It is 
+stored in the custom extensions section of the bundle.
 
 ```json
 {
-  "dependencies": {
+  "custom": {
+    "dependencies": {
       "requires": [
         {
           "bundle": "somecloud/blob-storage"
@@ -48,6 +50,7 @@ The bundle depends on a specific named bundle that is known in advance.
           }
         }
       ]
+    },
   },
   "name": "wordpress"
 }

--- a/500-CNAB-dependencies.md
+++ b/500-CNAB-dependencies.md
@@ -64,6 +64,9 @@ This section is a placeholder and will be completed in a follow-up pull request.
 This specification introduces a `dependencies` object in the bundle.json
 that defines metadata necessary to specify a dependency.
 
+The entry `dependencies` in the custom extension map, `custom`, is reserved and
+MUST only be used for this CNAB Dependencies Specification.
+
 ### requires
 
 The `requires` map defines the criteria for the dependent bundle. The key for

--- a/500-CNAB-dependencies.md
+++ b/500-CNAB-dependencies.md
@@ -35,17 +35,20 @@ The bundle depends on a specific named bundle that is known in advance.
 
 ```json
 {
-  "dependencies": [
-    {
-      "requires": {
-        "bundle": "azure/mysql",
-        "version": {
-          "prereleases": "true",
-          "range": "5.7.x"
+  "dependencies": {
+      "requires": [
+        {
+          "bundle": "somecloud/blob-storage"
+        },
+        {
+          "bundle": "somecloud/mysql",
+          "version": {
+            "prereleases": true,
+            "ranges": ["5.7.x"]
+          }
         }
-      }
-    }
-  ],
+      ]
+  },
   "name": "wordpress"
 }
 ```
@@ -56,12 +59,12 @@ This section is a placeholder and will be completed in a follow-up pull request.
 
 ## Dependencies Metadata
 
-This specification introduces a `dependencies` array in the bundle.json
+This specification introduces a `dependencies` object in the bundle.json
 that defines metadata necessary to specify a dependency.
 
 ### requires
 
-The `requires` object defines the criteria for the dependent bundle:
+The `requires` array defines the criteria for the dependent bundle:
 
 * `bundle`: A reference to a bundle in the format REGISTRY/NAME.
 * `version`: A set of criteria applied to the bundle version when selecting an

--- a/examples/500.01-dependencies.json
+++ b/examples/500.01-dependencies.json
@@ -1,15 +1,15 @@
 {
-    "requires": [
-        {
+    "requires": {
+        "blob": {
             "bundle": "somecloud/blob-storage"
         },
-        {
+        "mongo": {
             "bundle": "somecloud/mongo",
             "version":{
                 "prereleases": true
             }
         },
-        {
+        "mysql": {
             "bundle": "somecloud/mysql",
             "version": {
                 "prereleases": true,
@@ -18,5 +18,5 @@
                 ]
             }
         }
-    ]
+    }
 }

--- a/examples/500.01-dependencies.json
+++ b/examples/500.01-dependencies.json
@@ -1,0 +1,22 @@
+{
+    "requires": [
+        {
+            "bundle": "somecloud/blob-storage"
+        },
+        {
+            "bundle": "somecloud/mongo",
+            "version":{
+                "prereleases": true
+            }
+        },
+        {
+            "bundle": "somecloud/mysql",
+            "version": {
+                "prereleases": true,
+                "ranges": [
+                    "5.7.x"
+                ]
+            }
+        }
+    ]
+}

--- a/schema/dependencies.schema.json
+++ b/schema/dependencies.schema.json
@@ -1,0 +1,60 @@
+{
+    "$id": "http://cnab.io/v1/dependencies.schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "CNAB Dependencies JSON Schema",
+    "definitions": {
+        "requires": {
+            "type": "array",
+            "description": "Defines the criteria for the dependent bundle.",
+            "items": {
+                "$ref": "#/definitions/dependency"
+            },
+            "minItems": 1
+        },
+        "dependency": {
+            "type": "object",
+            "properties": {
+                "bundle": {
+                    "type": "string",
+                    "description": "A reference to a bundle in the format REGISTRY/NAME."
+                },
+                "version": {
+                    "$ref": "#/definitions/version"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "bundle"
+            ]
+        },
+        "version": {
+            "type": "object",
+            "description": "A set of criteria applied to the bundle version when selecting an acceptable version of the bundle.",
+            "properties": {
+                "ranges": {
+                    "type": "array",
+                    "description": "An array of allowed version ranges. Versions are specified using semver, with or without a leading 'v'. An x in the place of the minor or patch place can be used to specify a wildcard. Ranges can be specified by separating the two versions with a dash, the dash must be surrounded by spaces in order to disambiguate from prerelease tags.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1
+                },
+                "prereleases": {
+                    "type": "boolean",
+                    "description": "Specifies if prerelease versions of the bundle are allowed.",
+                    "default": false
+                }
+            },
+            "additionalProperties": false,
+            "minProperties": 1
+        }
+    },
+    "type": "object",
+    "properties": {
+        "requires": {
+            "$ref": "#/definitions/requires"
+        }
+    },
+    "additionalProperties": false,
+    "minProperties": 1
+}

--- a/schema/dependencies.schema.json
+++ b/schema/dependencies.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "http://cnab.io/v1/dependencies.schema.json",
+    "$id": "https://cnab.io/specs/v1/dependencies.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "CNAB Dependencies JSON Schema",
     "definitions": {

--- a/schema/dependencies.schema.json
+++ b/schema/dependencies.schema.json
@@ -4,12 +4,14 @@
     "title": "CNAB Dependencies JSON Schema",
     "definitions": {
         "requires": {
-            "type": "array",
-            "description": "Defines the criteria for the dependent bundle.",
-            "items": {
-                "$ref": "#/definitions/dependency"
+            "type": "object",
+            "description": "Defines the criteria for the dependent bundle. The key for each dependency is a way for the bundle to reference the dependency",
+            "patternProperties": {
+                ".*": {
+                    "$ref": "#/definitions/dependency"
+                }
             },
-            "minItems": 1
+            "minProperties": 1
         },
         "dependency": {
             "type": "object",

--- a/validate.sh
+++ b/validate.sh
@@ -21,7 +21,7 @@ for json in $(ls -1 examples/*-claim.json); do
   ajv test -s $schema -d $json --valid -r schema/bundle.schema.json
 done
 
-# Test all of the claim files against the claim schema.
+# Test all of the status files against the status schema.
 for json in $(ls -1 examples/*-status.json); do
   schema="schema/status.schema.json"
   echo "Testing json '$json' against schema '$schema'"
@@ -31,6 +31,13 @@ done
 # Test all of the relocation mapping files against the relocation mapping schema.
 for json in $(ls -1 examples/*-relocation-mapping.json); do
   schema="schema/relocation-mapping.schema.json"
+  echo "Testing json '$json' against schema '$schema'"
+  ajv test -s $schema -d $json --valid
+done
+
+# Test all of the dependency files against the dependencies schema
+for json in $(ls -1 examples/*-dependencies.json); do
+  schema="schema/dependencies.schema.json"
   echo "Testing json '$json' against schema '$schema'"
   ajv test -s $schema -d $json --valid
 done


### PR DESCRIPTION
* When I went to [add support for dependencies in cnab-go](https://github.com/deislabs/cnab-go/pull/55), I realized that the example json wasn't using array/object properly. This is what I get for writing json embedded in markdown... 🤦‍♀️
* Use bool instead of bool string for prereleases

**Update:** Since this isn't part of the core spec, it can't live at the root because that messes up the json schema valiation. So it will live under the custom extensions, custom.

* Add a json schema document
* Add a validation test for the schema doc