### PR TITLE
Adding "requiredExtensions" to core spec

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -856,7 +856,7 @@ The fields are defined as follows:
 
 Some extensions MAY be required by a bundle and operations involving that bundle MUST fail if the runtime does not support that bundle. In this case, a bundle author MUST use the `requiredExtensions` object to define those extensions that are necessary for installing the bundle. The `requiredExtensions` object should contain a collection of key/value pairs. The key MUST be the `EXTENSION NAME` and the value MUST be a well known JSON Schema reference that can be used to validate the JSON data contained in the `custom` object.
 
-A runtime MUST validate that it supports any defined custom actions before performing any operation. However, bundles SHOULD be installable by runtimes that do not understand the extensions if they are NOT identified in the `requiredExtensions` field.  
+A runtime SHOULD check that it supports any required custom actions before performing any operation. However, bundles SHOULD be installable by runtimes that do not support extensions that are NOT identified in the `requiredExtensions` field.  
 
 See [101.03-bundle.json](examples/101.03-bundle.json) for a complete example.
 

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -854,7 +854,7 @@ The fields are defined as follows:
 
 ### Required Extensions
 
-Some extensions MAY be required by a bundle and operations involving that bundle MUST fail if the runtime does not support that bundle. In this case, a bundle author MUST use the `requiredExtensions` array to define those extensions that are necessary for installing the bundle. The `requiredExtensions` array should contain the `EXTENSION NAME` defined in the `custom` object for any extensions that are required for bundle operations.
+Some extensions MAY be required by a bundle and operations involving that bundle MUST fail if the runtime does not support that extension. In this case, a bundle author MUST use the `requiredExtensions` array to define those extensions that are necessary for installing the bundle. The `requiredExtensions` array should contain the `EXTENSION NAME` defined in the `custom` object for any extensions that are required for bundle operations.
 
 A runtime SHOULD check that it supports any required custom actions before performing any operation. However, bundles SHOULD be installable by runtimes that do not support extensions that are NOT identified in the `requiredExtensions` field.  
 

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -854,7 +854,7 @@ The fields are defined as follows:
 
 ### Required Extensions
 
-Some extensions MAY be required by a bundle and operations involving that bundle MUST fail if the runtime does not support that extension. In this case, a bundle author MUST use the `requiredExtensions` array to define those extensions that are necessary for installing the bundle. The `requiredExtensions` array should contain the `EXTENSION NAME` defined in the `custom` object for any extensions that are required for bundle operations.
+Some extensions defined in the `custom` object of a bundle MAY be required in order for a runtime to perform any action on the bundle. A bundle author MUST use the `requiredExtensions` array to define those extensions that are required. The `requiredExtensions` array SHOULD contain the `EXTENSION NAME` defined in the `custom` object for each extension that is required.
 
 A runtime SHOULD check that it supports any required custom actions before performing any operation. However, bundles SHOULD be installable by runtimes that do not support extensions that are NOT identified in the `requiredExtensions` field.  
 

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -852,13 +852,19 @@ The fields are defined as follows:
   - `EXTENSION NAME`: a unique name for an extension. Names SHOULD follow the dotted name format described earlier in this section.
   - The value of the extension must be valid JSON, but is otherwise undefined.
 
-The usage of extensions is undefined. However, bundles SHOULD be installable by runtimes that do not understand the extensions.
+### Required Extensions
+
+Some extensions MAY be required by a bundle and operations involving that bundle MUST fail if the runtime does not support that bundle. In this case, a bundle author MUST use the `requiredExtensions` object to define those extensions that are necessary for installing the bundle. The `requiredExtensions` object should contain a collection of key/value pairs. The key MUST be the `EXTENSION NAME` and the value MUST be a well known JSON Schema reference that can be used to validate the JSON data contained in the `custom` object.
+
+A runtime MUST validate that it supports any defined custom actions before performing any operation. However, bundles SHOULD be installable by runtimes that do not understand the extensions if they are NOT identified in the `requiredExtensions` field.  
+
+See [101.03-bundle.json](examples/101.03-bundle.json) for a complete example.
 
 ## Outputs
 
 The `outputs` section of the `bundle.json` defines which outputs an application will produce during the course of executing a bundle. Outputs are expected to be written to one or more files on the file system of the invocation image. The location of this file MUST be provided in the output definition.
 
-Output specifications are flat (not tree-like), consisting of name/value pairs. The output definition includes a destination the output will be written to, along with a definition to help validate their contents.
+Output specifications are flat (not tree-like), consisting of name/value pairs. The output definition includes a destination the output will be written to, along with a definition to help validate their contents. 
 
 ```json
 {

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -856,7 +856,7 @@ The fields are defined as follows:
 
 Some extensions defined in the `custom` object of a bundle MAY be required in order for a runtime to perform any action on the bundle. A bundle author MUST use the `requiredExtensions` array to define those extensions that are required. The `requiredExtensions` array SHOULD contain the `EXTENSION NAME` defined in the `custom` object for each extension that is required.
 
-A runtime SHOULD check that it supports any required custom actions before performing any operation. However, bundles SHOULD be installable by runtimes that do not support extensions that are NOT identified in the `requiredExtensions` field.  
+A runtime MUST check that it supports any required extensions before performing any action on the bundle. If the runtime does not support the required extension(s), it MAY proceed with the action or fail, however it MUST notify the user that it does not support the required extension(s). Runtimes that do not support extensions that are NOT identified in the `requiredExtensions` field of a bundle SHOULD perform actions on the bundle. 
 
 ```json
 {

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -854,7 +854,7 @@ The fields are defined as follows:
 
 ### Required Extensions
 
-Some extensions MAY be required by a bundle and operations involving that bundle MUST fail if the runtime does not support that bundle. In this case, a bundle author MUST use the `requiredExtensions` array to define those extensions that are necessary for installing the bundle. The `requiredExtensions` object should contain the `EXTENSION NAME` defined in the `custom` object for any extensions that are required for bundle operations.
+Some extensions MAY be required by a bundle and operations involving that bundle MUST fail if the runtime does not support that bundle. In this case, a bundle author MUST use the `requiredExtensions` array to define those extensions that are necessary for installing the bundle. The `requiredExtensions` array should contain the `EXTENSION NAME` defined in the `custom` object for any extensions that are required for bundle operations.
 
 A runtime SHOULD check that it supports any required custom actions before performing any operation. However, bundles SHOULD be installable by runtimes that do not support extensions that are NOT identified in the `requiredExtensions` field.  
 

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -858,7 +858,119 @@ Some extensions MAY be required by a bundle and operations involving that bundle
 
 A runtime SHOULD check that it supports any required custom actions before performing any operation. However, bundles SHOULD be installable by runtimes that do not support extensions that are NOT identified in the `requiredExtensions` field.  
 
-See [101.03-bundle.json](examples/101.03-bundle.json) for a complete example.
+```json
+{
+  "credentials": {
+    "hostkey": {
+      "env": "HOST_KEY",
+      "path": "/etc/hostkey.txt"
+    }
+  },
+  "custom": {
+    "com.example.backup-preferences": {
+      "frequency": "daily"
+    },
+    "com.example.duffle-bag": {
+      "icon": "https://example.com/icon.png",
+      "iconType": "PNG"
+    },
+    "dependencies": [
+      {
+        "requires": {
+          "bundle": "azure/mysql",
+          "version": {
+            "prereleases": "true",
+            "range": "5.7.x"
+          }
+        }
+      }
+    ]
+  },
+  "definitions": {
+    "http_port": {
+      "default": 80,
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
+    },
+    "port": {
+      "maximum": 65535,
+      "minimum": 1024,
+      "type": "integer"
+    },
+    "string": {
+      "type": "string"
+    },
+    "x509Certificate": {
+      "contentEncoding": "base64",
+      "contentMediaType": "application/x-x509-user-cert",
+      "type": "string",
+      "writeOnly": true
+    }
+  },
+  "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
+  "images": {
+    "my-microservice": {
+      "contentDigest": "sha256:aaaaaaaaaaaa...",
+      "description": "my microservice",
+      "image": "technosophos/microservice:1.2.3"
+    }
+  },
+  "invocationImages": [
+    {
+      "contentDigest": "sha256:aaaaaaa...",
+      "image": "technosophos/helloworld:0.1.0",
+      "imageType": "docker"
+    }
+  ],
+  "maintainers": [
+    {
+      "email": "matt.butcher@microsoft.com",
+      "name": "Matt Butcher",
+      "url": "https://example.com"
+    }
+  ],
+  "name": "helloworld",
+  "outputs": {
+    "fields": {
+      "clientCert": {
+        "definition": "x509Certificate",
+        "path": "/cnab/app/outputs/clientCert"
+      },
+      "hostName": {
+        "applyTo": [
+          "install"
+        ],
+        "definition": "string",
+        "description": "the hostname produced installing the bundle",
+        "path": "/cnab/app/outputs/hostname"
+      },
+      "port": {
+        "definition": "port",
+        "path": "/cnab/app/outputs/port"
+      }
+    }
+  },
+  "parameters": {
+    "fields": {
+      "backend_port": {
+        "definition": "http_port",
+        "description": "The port that the back-end will listen on",
+        "destination": {
+          "env": "BACKEND_PORT"
+        }
+      }
+    }
+  },
+  "requiredExtensions": {
+    "dependencies": "cnab.io/specs/depenencies.schema.json"
+  },
+  "schemaVersion": "v1.0.0-WD",
+  "version": "0.1.2"
+}
+```
+
+Source: [101.03-bundle.json](examples/101.03-bundle.json)
 
 ## Outputs
 

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -854,7 +854,7 @@ The fields are defined as follows:
 
 ### Required Extensions
 
-Some extensions MAY be required by a bundle and operations involving that bundle MUST fail if the runtime does not support that bundle. In this case, a bundle author MUST use the `requiredExtensions` object to define those extensions that are necessary for installing the bundle. The `requiredExtensions` object should contain a collection of key/value pairs. The key MUST be the `EXTENSION NAME` and the value MUST be a well known JSON Schema reference that can be used to validate the JSON data contained in the `custom` object.
+Some extensions MAY be required by a bundle and operations involving that bundle MUST fail if the runtime does not support that bundle. In this case, a bundle author MUST use the `requiredExtensions` array to define those extensions that are necessary for installing the bundle. The `requiredExtensions` object should contain the `EXTENSION NAME` defined in the `custom` object for any extensions that are required for bundle operations.
 
 A runtime SHOULD check that it supports any required custom actions before performing any operation. However, bundles SHOULD be installable by runtimes that do not support extensions that are NOT identified in the `requiredExtensions` field.  
 
@@ -874,7 +874,7 @@ A runtime SHOULD check that it supports any required custom actions before perfo
       "icon": "https://example.com/icon.png",
       "iconType": "PNG"
     },
-    "dependencies": [
+    "io.cnab.dependencies": [
       {
         "requires": {
           "bundle": "azure/mysql",
@@ -962,9 +962,9 @@ A runtime SHOULD check that it supports any required custom actions before perfo
       }
     }
   },
-  "requiredExtensions": {
-    "dependencies": "cnab.io/specs/depenencies.schema.json"
-  },
+  "requiredExtensions": [
+    "io.cnab.dependencies"
+  ],
   "schemaVersion": "v1.0.0-WD",
   "version": "0.1.2"
 }

--- a/examples/101.03-bundle.json
+++ b/examples/101.03-bundle.json
@@ -1,0 +1,110 @@
+{
+    "credentials": {
+      "hostkey": {
+        "env": "HOST_KEY",
+        "path": "/etc/hostkey.txt"
+      }
+    },
+    "custom": {
+      "com.example.backup-preferences": {
+        "frequency": "daily"
+      },
+      "com.example.duffle-bag": {
+        "icon": "https://example.com/icon.png",
+        "iconType": "PNG"
+      },
+      "dependencies": [
+        {
+          "requires": {
+            "bundle": "azure/mysql",
+            "version": {
+              "prereleases": "true",
+              "range": "5.7.x"
+            }
+          }
+        }
+      ]
+    },
+    "definitions": {
+      "http_port": {
+        "default": 80,
+        "maximum": 10240,
+        "minimum": 10,
+        "type": "integer"
+      },
+      "port": {
+        "maximum": 65535,
+        "minimum": 1024,
+        "type": "integer"
+      },
+      "string": {
+        "type": "string"
+      },
+      "x509Certificate": {
+        "contentEncoding": "base64",
+        "contentMediaType": "application/x-x509-user-cert",
+        "type": "string",
+        "writeOnly": true
+      }
+    },
+    "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
+    "images": {
+      "my-microservice": {
+        "contentDigest": "sha256:aaaaaaaaaaaa...",
+        "description": "my microservice",
+        "image": "technosophos/microservice:1.2.3"
+      }
+    },
+    "invocationImages": [
+      {
+        "contentDigest": "sha256:aaaaaaa...",
+        "image": "technosophos/helloworld:0.1.0",
+        "imageType": "docker"
+      }
+    ],
+    "maintainers": [
+      {
+        "email": "matt.butcher@microsoft.com",
+        "name": "Matt Butcher",
+        "url": "https://example.com"
+      }
+    ],
+    "name": "helloworld",
+    "outputs": {
+      "fields": {
+        "clientCert": {
+          "definition": "x509Certificate",
+          "path": "/cnab/app/outputs/clientCert"
+        },
+        "hostName": {
+          "applyTo": [
+            "install"
+          ],
+          "definition": "string",
+          "description": "the hostname produced installing the bundle",
+          "path": "/cnab/app/outputs/hostname"
+        },
+        "port": {
+          "definition": "port",
+          "path": "/cnab/app/outputs/port"
+        }
+      }
+    },
+    "parameters": {
+      "fields": {
+        "backend_port": {
+          "definition": "http_port",
+          "description": "The port that the back-end will listen on",
+          "destination": {
+            "env": "BACKEND_PORT"
+          }
+        }
+      }
+    },
+    "requiredExtensions" : {
+        "dependencies" : "cnab.io/specs/depenencies.schema.json"
+    },
+    "schemaVersion": "v1.0.0-WD",
+    "version": "0.1.2"
+  }
+  

--- a/examples/101.03-bundle.json
+++ b/examples/101.03-bundle.json
@@ -1,110 +1,109 @@
 {
-    "credentials": {
-      "hostkey": {
-        "env": "HOST_KEY",
-        "path": "/etc/hostkey.txt"
-      }
+  "credentials": {
+    "hostkey": {
+      "env": "HOST_KEY",
+      "path": "/etc/hostkey.txt"
+    }
+  },
+  "custom": {
+    "com.example.backup-preferences": {
+      "frequency": "daily"
     },
-    "custom": {
-      "com.example.backup-preferences": {
-        "frequency": "daily"
-      },
-      "com.example.duffle-bag": {
-        "icon": "https://example.com/icon.png",
-        "iconType": "PNG"
-      },
-      "dependencies": [
-        {
-          "requires": {
-            "bundle": "azure/mysql",
-            "version": {
-              "prereleases": "true",
-              "range": "5.7.x"
-            }
+    "com.example.duffle-bag": {
+      "icon": "https://example.com/icon.png",
+      "iconType": "PNG"
+    },
+    "dependencies": [
+      {
+        "requires": {
+          "bundle": "azure/mysql",
+          "version": {
+            "prereleases": "true",
+            "range": "5.7.x"
           }
         }
-      ]
+      }
+    ]
+  },
+  "definitions": {
+    "http_port": {
+      "default": 80,
+      "maximum": 10240,
+      "minimum": 10,
+      "type": "integer"
     },
-    "definitions": {
-      "http_port": {
-        "default": 80,
-        "maximum": 10240,
-        "minimum": 10,
-        "type": "integer"
+    "port": {
+      "maximum": 65535,
+      "minimum": 1024,
+      "type": "integer"
+    },
+    "string": {
+      "type": "string"
+    },
+    "x509Certificate": {
+      "contentEncoding": "base64",
+      "contentMediaType": "application/x-x509-user-cert",
+      "type": "string",
+      "writeOnly": true
+    }
+  },
+  "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
+  "images": {
+    "my-microservice": {
+      "contentDigest": "sha256:aaaaaaaaaaaa...",
+      "description": "my microservice",
+      "image": "technosophos/microservice:1.2.3"
+    }
+  },
+  "invocationImages": [
+    {
+      "contentDigest": "sha256:aaaaaaa...",
+      "image": "technosophos/helloworld:0.1.0",
+      "imageType": "docker"
+    }
+  ],
+  "maintainers": [
+    {
+      "email": "matt.butcher@microsoft.com",
+      "name": "Matt Butcher",
+      "url": "https://example.com"
+    }
+  ],
+  "name": "helloworld",
+  "outputs": {
+    "fields": {
+      "clientCert": {
+        "definition": "x509Certificate",
+        "path": "/cnab/app/outputs/clientCert"
+      },
+      "hostName": {
+        "applyTo": [
+          "install"
+        ],
+        "definition": "string",
+        "description": "the hostname produced installing the bundle",
+        "path": "/cnab/app/outputs/hostname"
       },
       "port": {
-        "maximum": 65535,
-        "minimum": 1024,
-        "type": "integer"
-      },
-      "string": {
-        "type": "string"
-      },
-      "x509Certificate": {
-        "contentEncoding": "base64",
-        "contentMediaType": "application/x-x509-user-cert",
-        "type": "string",
-        "writeOnly": true
+        "definition": "port",
+        "path": "/cnab/app/outputs/port"
       }
-    },
-    "description": "An example 'thin' helloworld Cloud-Native Application Bundle",
-    "images": {
-      "my-microservice": {
-        "contentDigest": "sha256:aaaaaaaaaaaa...",
-        "description": "my microservice",
-        "image": "technosophos/microservice:1.2.3"
-      }
-    },
-    "invocationImages": [
-      {
-        "contentDigest": "sha256:aaaaaaa...",
-        "image": "technosophos/helloworld:0.1.0",
-        "imageType": "docker"
-      }
-    ],
-    "maintainers": [
-      {
-        "email": "matt.butcher@microsoft.com",
-        "name": "Matt Butcher",
-        "url": "https://example.com"
-      }
-    ],
-    "name": "helloworld",
-    "outputs": {
-      "fields": {
-        "clientCert": {
-          "definition": "x509Certificate",
-          "path": "/cnab/app/outputs/clientCert"
-        },
-        "hostName": {
-          "applyTo": [
-            "install"
-          ],
-          "definition": "string",
-          "description": "the hostname produced installing the bundle",
-          "path": "/cnab/app/outputs/hostname"
-        },
-        "port": {
-          "definition": "port",
-          "path": "/cnab/app/outputs/port"
+    }
+  },
+  "parameters": {
+    "fields": {
+      "backend_port": {
+        "definition": "http_port",
+        "description": "The port that the back-end will listen on",
+        "destination": {
+          "env": "BACKEND_PORT"
         }
       }
-    },
-    "parameters": {
-      "fields": {
-        "backend_port": {
-          "definition": "http_port",
-          "description": "The port that the back-end will listen on",
-          "destination": {
-            "env": "BACKEND_PORT"
-          }
-        }
-      }
-    },
-    "requiredExtensions" : {
-        "dependencies" : "cnab.io/specs/depenencies.schema.json"
-    },
-    "schemaVersion": "v1.0.0-WD",
-    "version": "0.1.2"
-  }
-  
+    }
+  },
+  "requiredExtensions": {
+    "dependencies": "cnab.io/specs/depenencies.schema.json"
+  },
+  "schemaVersion": "v1.0.0-WD",
+  "version": "0.1.2"
+}

--- a/examples/101.03-bundle.json
+++ b/examples/101.03-bundle.json
@@ -13,7 +13,7 @@
       "icon": "https://example.com/icon.png",
       "iconType": "PNG"
     },
-    "dependencies": [
+    "io.cnab.dependencies": [
       {
         "requires": {
           "bundle": "azure/mysql",
@@ -101,9 +101,9 @@
       }
     }
   },
-  "requiredExtensions": {
-    "dependencies": "cnab.io/specs/depenencies.schema.json"
-  },
+  "requiredExtensions": [
+    "io.cnab.dependencies"
+  ],
   "schemaVersion": "v1.0.0-WD",
   "version": "0.1.2"
 }

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -224,7 +224,9 @@
       "type": "object"
     },
     "custom": {
-      "$comment": "reserved for custom extensions"
+      "$comment": "reserved for custom extensions",
+      "type": "object",
+      "additionalProperties": true
     },
     "definitions": {
       "additionalProperties": {
@@ -316,6 +318,11 @@
         }
       },
       "type": "object"
+    },
+    "requiredExtensions": {
+      "description": "A collection of extensions required for this bundle. Key/value pairs of an identifier and a schema URI.",
+      "type": "object",
+      "additionalProperties": {"type": "string"}
     },
     "schemaVersion": {
       "description": "The version of the CNAB specification. This should always be the string 'v1' for this schema version.",

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -320,7 +320,7 @@
       "type": "object"
     },
     "requiredExtensions": {
-      "description": "A collection of extensions required for this bundle. Key/value pairs of an identifier and a schema URI.",
+      "description": "A collection of extensions required for this bundle. Key/value pairs of an identifier and a schema URL.",
       "type": "object",
       "additionalProperties": {"type": "string"}
     },

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -320,8 +320,8 @@
       "type": "object"
     },
     "requiredExtensions": {
-      "description": "A collection of extensions required for this bundle. Key/value pairs of an identifier and a schema URL.",
-      "type": "object",
+      "description": "A collection of extensions required for this bundle.",
+      "type": "array",
       "additionalProperties": {"type": "string"}
     },
     "schemaVersion": {


### PR DESCRIPTION
This PR introduces a `requiredExtensions` object and modifies
the wording of 101-bundle-json.md to refine the existing custom
extensions section. Relevant example and JSON schema changes included.