### PR TITLE
fix: terminology and grammar

### DIFF
--- a/100-CNAB.md
+++ b/100-CNAB.md
@@ -68,13 +68,13 @@ Invocation images allow limited configuration, as defined in two places in the b
 - Invocation Image: The image that contains the bootstrapping and installation logic for the bundle
 - Registry: A storage and retrieval service for CNAB objects.
 
-Also, when referencing tooling, we use the following terms:
+Also, when referencing tooling, the following terms are used:
 
 - `CNAB runtime` or `runtime`: A program capable of reading a CNAB bundle and executing it
 - `CNAB builder` or `builder`: A program that can assemble a CNAB bundle
 - `bundle tooling`: Programs or tooling that generate CNAB bundle contents
 
-Individual tools may meet more than one of the definitions above, but we have chosen to separate them in order to offer guidance such as:
+Individual tools may meet more than one of the definitions above, they have been separated in order to offer guidance such as:
 
 > A runtime MUST support the 'install', 'upgrade', and 'uninstall' actions, while bundle tooling MAY choose not to implement 'upgrade'.
 

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -30,7 +30,7 @@ The `bundle.json` is located at `/cnab/bundle.json` in the invocation image's ru
 
 The `bundle.json` is also known as a _thin bundle_. Bundles come in two formats: thick and thin. Read more about thick and thin bundles in the [bundle formats section](104-bundle-formats.md).
 
-For the rest of the documentation, by default we'll be referring to bundles using the "thin" type, but when "thick" bundles become relevant we'll make note that it's a "thick" bundle type.
+The examples given in this documentation predominantly use thin bundles. Examples of thick bundles will be noted as such.
 
 The following is an example of a `bundle.json` for a bundled distributed as a _thin_ bundle:
 
@@ -139,7 +139,7 @@ The canonical JSON version of the above is:
 {"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"},"port":{"maximum":65535,"minimum":1024,"type":"integer"},"string":{"type":"string"},"x509Certificate":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","type":"string","writeOnly":true}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"technosophos/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"fields":{"clientCert":{"definition":"x509Certificate","path":"/cnab/app/outputs/clientCert"},"hostName":{"applyTo":["install"],"definition":"string","description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname"},"port":{"definition":"port","path":"/cnab/app/outputs/port"}}},"parameters":{"fields":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
 ```
 
-And here is how a "thick" bundle looks. Notice how the `invocationImage` and `images` fields reference the underlying docker image manifest (`application/vnd.docker.distribution.manifest.v2+json`), which in turn references the underlying images:
+What follows is an example of a thick bundle. Notice how the `invocationImage` and `images` fields reference the underlying docker image manifest (`application/vnd.docker.distribution.manifest.v2+json`), which in turn references the underlying images:
 
 ```json
 {

--- a/104-bundle-formats.md
+++ b/104-bundle-formats.md
@@ -5,13 +5,13 @@ weight: 104
 
 # Bundle Formats
 
-This section of the specification addresses how bundles are to be represented. The CNAB Core specification defines two representations ("thick" and "thin"), and any CNAB compliant bundle MUST be representable in both formats. CNAB runtimes MUST support thin bundles, and SHOULD support thick bundles. Various other CNAB tools MAY support only one or the other. For example, a bundle builder could support generating thick bundles, but not thin bundles, and yet still meet the requirements of the specification.
+This section of the specification addresses how bundles are to be represented. The CNAB Core specification defines two representations (thick and thin), and any CNAB compliant bundle MUST be representable in both formats. CNAB runtimes MUST support thin bundles, and SHOULD support thick bundles. Various other CNAB tools MAY support only one or the other. For example, a bundle builder could support generating thick bundles, but not thin bundles, and yet still meet the requirements of the specification.
 
 Thick bundles do impose a slightly heavier burden on the runtime, and thus the specification allows that some runtimes might have pragmatic reasons for not supporting a thick bundle. Such runtimes MUST produce an error when given a thick bundle.
 
 ## Thick and Thin Bundles
 
-The thick and thin bundle formats refer to how much information must be transmitted in a package. Due to the nature of cloud technologies, it is sometimes possible (and desirable) to move a small artifact that references other external artifacts. In other cases, it is desirable to have one large self-contained artifact that depends on no external artifacts. CNAB represents the former as a _thin bundle_ and the later as a _thick bundle_.
+The thick and thin bundle formats refer to how much information must be transmitted in a package. Due to the nature of cloud technologies, it is sometimes possible (and desirable) to move a small artifact that references other external artifacts. In other cases, it is desirable to have one large self-contained artifact that depends on no external artifacts. CNAB represents the former as a thin bundle and the later as a thick bundle.
 
 A thin bundle contains only one object: The bundle descriptor. Thus, the format for a thin bundle is a JSON file.
 

--- a/805-airgap.md
+++ b/805-airgap.md
@@ -15,7 +15,7 @@ environment such that the bundle can be installed and the bundled software execu
 ## Internet Access
 
 A typical disconnected scenario will have limited, intermittent or no internet access, whether by design or by situation.
-To install a bundle directly in a disconnected environment, the bundle and its images need to be included in a [CNAB Thick Bundle](104-bundle-formats.md)
+To install a bundle directly in a disconnected environment, the bundle and its images need to be included in a [CNAB thick bundle](104-bundle-formats.md)
 and transferred into the disconnected environment, for instance on a USB stick.
 
 Alternatively, if a DMZ is available, it may be possible to read the bundle and/or its images from an external network
@@ -40,15 +40,15 @@ A private registry:
 
 ## CNAB Thick Bundles
 
-A CNAB Thick Bundle provides a convenient archive format for transferring a bundle and its images into a 
-disconnected environment. But Thick Bundles have other benefits.
+A CNAB thick bundle provides a convenient archive format for transferring a bundle and its images into a 
+disconnected environment. But thick bundles have other benefits.
 
 A CNAB bundle may reference artifacts that are hosted in different repositories or registries.
 These remote artifacts may change over time without changing the references.
 If the digests of artifacts are provided in the bundle, the content of the artifacts cannot change without
 changing the digests, but even then the artifacts, or their repositories or registries, may be deleted.
 
-Archiving a CNAB and its images at a point of time as a CNAB Thick Bundle
+Archiving a CNAB and its images at a point of time as a CNAB thick bundle
 provides protection against modification or deletion of images and also provides a central location for code
 auditing and digital forensics of all code and references used in the CNAB.
 


### PR DESCRIPTION
- Usage of the terms thick and thin have been standardized
- "we" has been removed, replaced with passive voice
- Other small grammatical fixes have been made

Closes #210