### PR TITLE
Make "required" a property of parameter

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -115,13 +115,11 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
     }
   },
   "parameters": {
-    "fields": {
-      "backend_port": {
-        "definition": "http_port",
-        "description": "The port that the back-end will listen on",
-        "destination": {
-          "env": "BACKEND_PORT"
-        }
+    "backend_port": {
+      "definition": "http_port",
+      "description": "The port that the back-end will listen on",
+      "destination": {
+        "env": "BACKEND_PORT"
       }
     }
   },
@@ -136,7 +134,7 @@ The canonical JSON version of the above is:
 
 <!-- prettier-ignore -->
 ```json
-{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"},"port":{"maximum":65535,"minimum":1024,"type":"integer"},"string":{"type":"string"},"x509Certificate":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","type":"string","writeOnly":true}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"technosophos/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"fields":{"clientCert":{"definition":"x509Certificate","path":"/cnab/app/outputs/clientCert"},"hostName":{"applyTo":["install"],"definition":"string","description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname"},"port":{"definition":"port","path":"/cnab/app/outputs/port"}}},"parameters":{"fields":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
+{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"},"port":{"maximum":65535,"minimum":1024,"type":"integer"},"string":{"type":"string"},"x509Certificate":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","type":"string","writeOnly":true}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"technosophos/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"fields":{"clientCert":{"definition":"x509Certificate","path":"/cnab/app/outputs/clientCert"},"hostName":{"applyTo":["install"],"definition":"string","description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname"},"port":{"definition":"port","path":"/cnab/app/outputs/port"}}},"parameters":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
 ```
 
 And here is how a "thick" bundle looks. Notice how the `invocationImage` and `images` fields reference the underlying docker image manifest (`application/vnd.docker.distribution.manifest.v2+json`), which in turn references the underlying images:
@@ -224,15 +222,13 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
     }
   },
   "parameters": {
-    "fields": {
-      "backend_port": {
-        "definition": "http_port",
-        "description": "The port that the backend will listen on",
-        "destination": {
-          "path": "/path/to/backend_port"
-        },
-        "immutable": true
-      }
+    "backend_port": {
+      "definition": "http_port",
+      "description": "The port that the backend will listen on",
+      "destination": {
+        "path": "/path/to/backend_port"
+      },
+      "immutable": true
     }
   },
   "schemaVersion": "v1.0.0-WD",
@@ -437,36 +433,33 @@ Parameter specifications consist of name/value pairs. The name is fixed, but the
     }
   },
   "parameters": {
-    "fields": {
-      "backend_port": {
-        "applyTo": ["install", "action1", "action2"],
-        "definition": "http_port",
-        "description": "The port that the backend will listen on",
-        "destination": {
-          "env": "MY_ENV_VAR",
-          "path": "/my/destination/path"
-        }
-      }
-    },
-    "required": ["backend_port"]
+    "backend_port": {
+      "applyTo": ["install", "action1", "action2"],
+      "definition": "http_port",
+      "description": "The port that the backend will listen on",
+      "destination": {
+        "env": "MY_ENV_VAR",
+        "path": "/my/destination/path"
+      },
+      "required": true
+    }
   }
 }
 ```
 
-- `parameters`: A collection of parameter definitions and a list of those parameters that are required.
-  - `fields`: name/value pairs describing a user-overridable parameter:
-    - `<name>`: The name of the parameter. In the example above, this is `backend_port`. This
-      is mapped to a value definition, which contains the following fields (REQUIRED):
-      - `applyTo`: restricts this parameter to a given list of actions. If empty or missing, applies to all actions (OPTIONAL)
-      - `definition`: The name of a definition schema that is used to validate user-input for this parameter. (REQUIRED)
-      - `description`: Descriptive text for the field. Can be used to decorate a user interface. MUST be a string. (OPTIONAL)
-      - `destination`: Indicates where (in the invocation image) the parameter is to be written (REQUIRED)
-        - `env`: The name of an environment variable
-        - `path`: The fully qualified path to a file that will be created. Specified path MUST NOT be a subpath of `/cnab/app/outputs`.
-      - `immutable`: an immutable parameter may only be set at installation. The value of the parameter cannot be changed. MUST be a boolean. Default value is false. (OPTIONAL).
-  - `required`: A list of required parameters. MUST be an array of strings.(OPTIONAL)
+- `parameters`: Name/value pairs describing a user-overridable parameter.
+  - `<name>`: The name of the parameter. In the example above, this is `backend_port`. This
+    is mapped to a value definition, which contains the following fields (REQUIRED):
+    - `applyTo`: restricts this parameter to a given list of actions. If empty or missing, applies to all actions (OPTIONAL)
+    - `definition`: The name of a definition schema that is used to validate user-input for this parameter. (REQUIRED)
+    - `description`: Descriptive text for the field. Can be used to decorate a user interface. MUST be a string. (OPTIONAL)
+    - `destination`: Indicates where (in the invocation image) the parameter is to be written (REQUIRED)
+      - `env`: The name of an environment variable
+      - `path`: The fully qualified path to a file that will be created. Specified path MUST NOT be a subpath of `/cnab/app/outputs`.
+    - `immutable`: an immutable parameter may only be set at installation. The value of the parameter cannot be changed. MUST be a boolean. Default value is false. (OPTIONAL).
+    - `required`: indicates whether this parameter MUST be supplied. By default it is `false`, which means the parameter is optional. When `true`, a runtime MUST fail if the parameter is not provided for any action to which the parameter applies.
 
-Parameter names (the keys in `fields`) ought to conform to the [Open Group Base Specification Issue 6, Section 8.1, paragraph 4](http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html) definition of environment variable names with one exception: parameter names MAY begin with a digit (approximately `[A-Z0-9_]+`).
+Parameter names (the keys in `parameters`) ought to conform to the [Open Group Base Specification Issue 6, Section 8.1, paragraph 4](http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html) definition of environment variable names with one exception: parameter names MAY begin with a digit (approximately `[A-Z0-9_]+`).
 
 > The term _parameters_ indicates the present specification of what can be provided to a bundle. The term _values_ is frequently used to indicate the user-supplied values which are tested against the parameter definitions.
 
@@ -535,19 +528,17 @@ The structure of a `parameters` and `definitions` section looks like the section
     }
   },
   "parameters": {
-    "fields" : {
-      "<parameter-name>": {
-        "applyTo": [ <string> ],
-        "definition": <definition-name>,
-        "description": <string>,
-        "destination": {
-          "env": <string>,
-          "path": <string>
-        },
-        "immutable" : <boolean>
-      }
-    },
-    "required": [ <string> ]
+    "<parameter-name>": {
+      "applyTo": [ <string> ],
+      "definition": <definition-name>,
+      "description": <string>,
+      "destination": {
+        "env": <string>,
+        "path": <string>
+      },
+      "immutable" : <boolean>,
+      "required" : <boolean>
+    }
   }
 }
 ```
@@ -614,35 +605,33 @@ Check out the [JSON Schema specification](https://json-schema.org/) for more exa
     }
   },
   "parameters": {
-    "fields": {
-      "email": {
-        "definition": "email-address",
-        "destination": {
-          "env": "EMAIL"
-        }
-      },
-      "greetings": {
-        "definition": "greetings",
-        "destination": {
-          "env": "GREETINGS"
-        }
-      },
-      "profile_picture": {
-        "definition": "jpeg",
-        "destination": {
-          "path": "/tmp/user.jpg"
-        }
-      },
-      "workplace_address": {
-        "definition": "address",
-        "description": "the address of your workplace",
-        "destination": {
-          "path": "/tmp/address.adr"
-        }
+    "email": {
+      "definition": "email-address",
+      "destination": {
+        "env": "EMAIL"
       }
+    },
+    "greetings": {
+      "definition": "greetings",
+      "destination": {
+        "env": "GREETINGS"
+      }
+    },
+    "profile_picture": {
+      "definition": "jpeg",
+      "destination": {
+        "path": "/tmp/user.jpg"
+      }
+    },
+    "workplace_address": {
+      "definition": "address",
+      "description": "the address of your workplace",
+      "destination": {
+        "path": "/tmp/address.adr"
+      },
+      "required": true
     }
-  },
-  "required": ["workplace_address"]
+  }
 }
 ```
 
@@ -663,20 +652,18 @@ When resolving destinations, there are two ways a particular parameter value MAY
     }
   },
   "parameters": {
-    "fields": {
-      "config": {
-        "definition": "configuration",
-        "description": "this will be located in a file",
-        "destination": {
-          "path": "/opt/example-parameters/config.txt"
-        }
-      },
-      "greeting": {
-        "definition": "greeting",
-        "description": "this will be in $GREETING",
-        "destination": {
-          "env": "GREETING"
-        }
+    "config": {
+      "definition": "configuration",
+      "description": "this will be located in a file",
+      "destination": {
+        "path": "/opt/example-parameters/config.txt"
+      }
+    },
+    "greeting": {
+      "definition": "greeting",
+      "description": "this will be in $GREETING",
+      "destination": {
+        "env": "GREETING"
       }
     }
   }
@@ -724,7 +711,7 @@ What about parameters such as database passwords used by the application? Proper
     - `path` describes the _absolute path within the invocation image_ where the invocation image expects to find the credential. Specified path MUST NOT be a subpath of `/cnab/app/outputs`.
     - `env` contains _the name of an environment variable_ that the invocation image expects to have available when executing the CNAB `run` tool (covered in the next section).
     - `description` contains a user-friendly description of the credential.
-    - `required` indicates whether this credential MUST be supplied. By default, it is `false`, which means the credential is optional. When `true`, a runtime MUST fail if the credential is not provided.
+    - `required` indicates whether this credential MUST be supplied. By default it is `false`, which means the credential is optional. When `true`, a runtime MUST fail if the credential is not provided.
 
 One of `env` or `path` MUST be specified. (Both MAY be provided).
 
@@ -929,13 +916,11 @@ A runtime MUST check that it supports any required extensions before performing 
     }
   },
   "parameters": {
-    "fields": {
-      "backend_port": {
-        "definition": "http_port",
-        "description": "The port that the back-end will listen on",
-        "destination": {
-          "env": "BACKEND_PORT"
-        }
+    "backend_port": {
+      "definition": "http_port",
+      "description": "The port that the back-end will listen on",
+      "destination": {
+        "env": "BACKEND_PORT"
       }
     }
   },

--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -103,9 +103,7 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
         "path": "/cnab/app/outputs/clientCert"
       },
       "hostName": {
-        "applyTo": [
-          "install"
-        ],
+        "applyTo": ["install"],
         "definition": "string",
         "description": "the hostname produced installing the bundle",
         "path": "/cnab/app/outputs/hostname"
@@ -131,10 +129,12 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
   "version": "0.1.2"
 }
 ```
+
 Source: [101.01-bundle.json](examples/101.01-bundle.json)
 
 The canonical JSON version of the above is:
 
+<!-- prettier-ignore -->
 ```json
 {"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"},"port":{"maximum":65535,"minimum":1024,"type":"integer"},"string":{"type":"string"},"x509Certificate":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","type":"string","writeOnly":true}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"technosophos/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"fields":{"clientCert":{"definition":"x509Certificate","path":"/cnab/app/outputs/clientCert"},"hostName":{"applyTo":["install"],"definition":"string","description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname"},"port":{"definition":"port","path":"/cnab/app/outputs/port"}}},"parameters":{"fields":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
 ```
@@ -212,9 +212,7 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
         "path": "/cnab/app/outputs/clientCert"
       },
       "hostName": {
-        "applyTo": [
-          "install"
-        ],
+        "applyTo": ["install"],
         "definition": "string",
         "description": "the hostname produced installing the bundle",
         "path": "/cnab/app/outputs/hostname"
@@ -233,7 +231,7 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
         "destination": {
           "path": "/path/to/backend_port"
         },
-        "immutable" : true
+        "immutable": true
       }
     }
   },
@@ -241,6 +239,7 @@ And here is how a "thick" bundle looks. Notice how the `invocationImage` and `im
   "version": "1.0.0"
 }
 ```
+
 Source: [101.02-bundle.json](examples/101.02-bundle.json)
 
 In descriptions below, fields marked REQUIRED MUST be present in any conformant bundle descriptor, while fields not thusly marked are considered optional.
@@ -440,11 +439,7 @@ Parameter specifications consist of name/value pairs. The name is fixed, but the
   "parameters": {
     "fields": {
       "backend_port": {
-        "applyTo": [
-          "install",
-          "action1",
-          "action2"
-        ],
+        "applyTo": ["install", "action1", "action2"],
         "definition": "http_port",
         "description": "The port that the backend will listen on",
         "destination": {
@@ -453,9 +448,7 @@ Parameter specifications consist of name/value pairs. The name is fixed, but the
         }
       }
     },
-    "required": [
-      "backend_port"
-    ]
+    "required": ["backend_port"]
   }
 }
 ```
@@ -463,7 +456,7 @@ Parameter specifications consist of name/value pairs. The name is fixed, but the
 - `parameters`: A collection of parameter definitions and a list of those parameters that are required.
   - `fields`: name/value pairs describing a user-overridable parameter:
     - `<name>`: The name of the parameter. In the example above, this is `backend_port`. This
-    is mapped to a value definition, which contains the following fields (REQUIRED):
+      is mapped to a value definition, which contains the following fields (REQUIRED):
       - `applyTo`: restricts this parameter to a given list of actions. If empty or missing, applies to all actions (OPTIONAL)
       - `definition`: The name of a definition schema that is used to validate user-input for this parameter. (REQUIRED)
       - `description`: Descriptive text for the field. Can be used to decorate a user interface. MUST be a string. (OPTIONAL)
@@ -605,16 +598,10 @@ Check out the [JSON Schema specification](https://json-schema.org/) for more exa
       "type": "string"
     },
     "greetings": {
-      "default": [
-        "Hello"
-      ],
+      "default": ["Hello"],
       "description": "a list of greetings",
       "items": {
-        "examples": [
-          "Aloha",
-          "Bonjour",
-          "こんにちは"
-        ],
+        "examples": ["Aloha", "Bonjour", "こんにちは"],
         "type": "string"
       },
       "title": "Greetings for new users",
@@ -655,9 +642,7 @@ Check out the [JSON Schema specification](https://json-schema.org/) for more exa
       }
     }
   },
-  "required": [
-    "workplace_address"
-  ]
+  "required": ["workplace_address"]
 }
 ```
 
@@ -747,7 +732,6 @@ If `env` is set, the value of the credential MUST be assigned to the given envir
 
 If `path` is set, the value of the credential MUST be written into a file at the specified location on the invocation image's filesystem. This file name MUST NOT be present already on the invocation image's filesystem.
 
-
 ### Resolving Destination Conflicts in Environment Variables and Paths
 
 Parameters and credentials may specify environment variables or paths as destinations.
@@ -757,7 +741,7 @@ Parameters and credentials may specify environment variables or paths as destina
 - Implementations MUST NOT override a credential value with a parameter value
 - Implementations SHOULD NOT allow any parameter or credential to declare an environment variable with the prefix `CNAB_`
 - Implementations MUST NOT allow a parameter or credential to override any environment variable with the `CNAB_` prefix
-    - The `CNAB_` variables are defined in the [Bundle Runtime Description](./103-bundle-runtime.md) of this specification
+  - The `CNAB_` variables are defined in the [Bundle Runtime Description](./103-bundle-runtime.md) of this specification
 
 ## Custom Actions
 
@@ -851,7 +835,7 @@ The fields are defined as follows:
 
 Some extensions defined in the `custom` object of a bundle MAY be required in order for a runtime to perform any action on the bundle. A bundle author MUST use the `requiredExtensions` array to define those extensions that are required. The `requiredExtensions` array SHOULD contain the `EXTENSION NAME` defined in the `custom` object for each extension that is required.
 
-A runtime MUST check that it supports any required extensions before performing any action on the bundle. If the runtime does not support the required extension(s), it MAY proceed with the action or fail, however it MUST notify the user that it does not support the required extension(s). Runtimes that do not support extensions that are NOT identified in the `requiredExtensions` field of a bundle SHOULD perform actions on the bundle. 
+A runtime MUST check that it supports any required extensions before performing any action on the bundle. If the runtime does not support the required extension(s), it MAY proceed with the action or fail, however it MUST notify the user that it does not support the required extension(s). Runtimes that do not support extensions that are NOT identified in the `requiredExtensions` field of a bundle SHOULD perform actions on the bundle.
 
 ```json
 {
@@ -933,9 +917,7 @@ A runtime MUST check that it supports any required extensions before performing 
         "path": "/cnab/app/outputs/clientCert"
       },
       "hostName": {
-        "applyTo": [
-          "install"
-        ],
+        "applyTo": ["install"],
         "definition": "string",
         "description": "the hostname produced installing the bundle",
         "path": "/cnab/app/outputs/hostname"
@@ -957,9 +939,7 @@ A runtime MUST check that it supports any required extensions before performing 
       }
     }
   },
-  "requiredExtensions": [
-    "io.cnab.dependencies"
-  ],
+  "requiredExtensions": ["io.cnab.dependencies"],
   "schemaVersion": "v1.0.0-WD",
   "version": "0.1.2"
 }
@@ -971,7 +951,7 @@ Source: [101.03-bundle.json](examples/101.03-bundle.json)
 
 The `outputs` section of the `bundle.json` defines which outputs an application will produce during the course of executing a bundle. Outputs are expected to be written to one or more files on the file system of the invocation image. The location of this file MUST be provided in the output definition.
 
-Output specifications are flat (not tree-like), consisting of name/value pairs. The output definition includes a destination the output will be written to, along with a definition to help validate their contents. 
+Output specifications are flat (not tree-like), consisting of name/value pairs. The output definition includes a destination the output will be written to, along with a definition to help validate their contents.
 
 ```json
 {
@@ -994,10 +974,7 @@ Output specifications are flat (not tree-like), consisting of name/value pairs. 
   "outputs": {
     "fields": {
       "clientCert": {
-        "applyTo": [
-          "install",
-          "action2"
-        ],
+        "applyTo": ["install", "action2"],
         "definition": "x509Certificate",
         "path": "/cnab/app/outputs/clientCert"
       },

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -22,6 +22,7 @@ The run tool MUST observe standard conventions for executing, exiting, and writi
 - The special output stream STDERR should be used to write error text
 
 ### Bundle Definition
+
 The bundle definition is made accessible from inside the invocation image in order to allow the run tool to reference information in the file. The `bundle.json` MUST be mounted to `/cnab/bundle.json`.
 
 ### Injecting Data Into the Invocation Image
@@ -117,13 +118,11 @@ If the `destination` field contains a key named `env`, values MUST be passed int
     }
   },
   "parameters": {
-    "fields": {
-      "greeting": {
-        "definition": "greeting",
-        "description": "this will be in $GREETING",
-        "destination": {
-          "env": "GREETING"
-        }
+    "greeting": {
+      "definition": "greeting",
+      "description": "this will be in $GREETING",
+      "destination": {
+        "env": "GREETING"
       }
     }
   }
@@ -153,13 +152,11 @@ In the case where the `destination` object has a `path` field, the CNAB runtime 
     }
   },
   "parameters": {
-    "fields": {
-      "greeting": {
-        "definition": "greeting",
-        "description": "this will be in $GREETING",
-        "destination": {
-          "path": "/var/run/greeting.txt"
-        }
+    "greeting": {
+      "definition": "greeting",
+      "description": "this will be in $GREETING",
+      "destination": {
+        "path": "/var/run/greeting.txt"
       }
     }
   }
@@ -205,10 +202,11 @@ For example, if a CNAB bundle with an image `gabrtv/microservice@sha256:cca460af
 
 ```json
 {
- "gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687": "my.registry/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
- "technosophos/helloworld:0.1.0": "my.registry/helloworld:0.1.0"
+  "gabrtv/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687": "my.registry/microservice@sha256:cca460afa270d4c527981ef9ca4989346c56cf9b20217dcea37df1ece8120687",
+  "technosophos/helloworld:0.1.0": "my.registry/helloworld:0.1.0"
 }
 ```
+
 Source: [103.01-relocation-mapping.json](examples/103.01-relocation-mapping.json)
 
 The run tool MAY use this file to modify its behavior. For example, a run tool MAY substitute image references using the mapping in this file.

--- a/examples/101.01-bundle.json
+++ b/examples/101.01-bundle.json
@@ -66,9 +66,7 @@
         "path": "/cnab/app/outputs/clientCert"
       },
       "hostName": {
-        "applyTo": [
-          "install"
-        ],
+        "applyTo": ["install"],
         "definition": "string",
         "description": "the hostname produced installing the bundle",
         "path": "/cnab/app/outputs/hostname"
@@ -80,13 +78,11 @@
     }
   },
   "parameters": {
-    "fields": {
-      "backend_port": {
-        "definition": "http_port",
-        "description": "The port that the back-end will listen on",
-        "destination": {
-          "env": "BACKEND_PORT"
-        }
+    "backend_port": {
+      "definition": "http_port",
+      "description": "The port that the back-end will listen on",
+      "destination": {
+        "env": "BACKEND_PORT"
       }
     }
   },

--- a/examples/101.02-bundle.json
+++ b/examples/101.02-bundle.json
@@ -68,9 +68,7 @@
         "path": "/cnab/app/outputs/clientCert"
       },
       "hostName": {
-        "applyTo": [
-          "install"
-        ],
+        "applyTo": ["install"],
         "definition": "string",
         "description": "the hostname produced installing the bundle",
         "path": "/cnab/app/outputs/hostname"
@@ -82,15 +80,13 @@
     }
   },
   "parameters": {
-    "fields": {
-      "backend_port": {
-        "definition": "http_port",
-        "description": "The port that the backend will listen on",
-        "destination": {
-          "path": "/path/to/backend_port"
-        },
-        "immutable" : true
-      }
+    "backend_port": {
+      "definition": "http_port",
+      "description": "The port that the backend will listen on",
+      "destination": {
+        "path": "/path/to/backend_port"
+      },
+      "immutable": true
     }
   },
   "schemaVersion": "v1.0.0-WD",

--- a/examples/101.03-bundle.json
+++ b/examples/101.03-bundle.json
@@ -77,9 +77,7 @@
         "path": "/cnab/app/outputs/clientCert"
       },
       "hostName": {
-        "applyTo": [
-          "install"
-        ],
+        "applyTo": ["install"],
         "definition": "string",
         "description": "the hostname produced installing the bundle",
         "path": "/cnab/app/outputs/hostname"
@@ -91,19 +89,15 @@
     }
   },
   "parameters": {
-    "fields": {
-      "backend_port": {
-        "definition": "http_port",
-        "description": "The port that the back-end will listen on",
-        "destination": {
-          "env": "BACKEND_PORT"
-        }
+    "backend_port": {
+      "definition": "http_port",
+      "description": "The port that the back-end will listen on",
+      "destination": {
+        "env": "BACKEND_PORT"
       }
     }
   },
-  "requiredExtensions": [
-    "io.cnab.dependencies"
-  ],
+  "requiredExtensions": ["io.cnab.dependencies"],
   "schemaVersion": "v1.0.0-WD",
   "version": "0.1.2"
 }

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -158,6 +158,11 @@
           "description": "A flag indicating if the parameter value can be changed once it is set",
           "type": "boolean",
           "default": false
+        },
+        "required": {
+          "default": false,
+          "description": "Indicates whether this parameter must be supplied. By default, parameters are optional.",
+          "type": "boolean"
         }
       },
       "required": ["definition", "destination"],
@@ -275,18 +280,10 @@
       "type": "object"
     },
     "parameters": {
-      "description": "Parameters that can be injected into the invocation image",
-      "properties": {
-        "fields": {
-          "additionalProperties": {
-            "$ref": "#/definitions/parameter"
-          },
-          "type": "object"
-        },
-        "required": {
-          "$ref": "http://json-schema.org/draft-07/schema#/properties/required"
-        }
+      "additionalProperties": {
+        "$ref": "#/definitions/parameter"
       },
+      "description": "Parameters that can be injected into the invocation image",
       "type": "object"
     },
     "requiredExtensions": {

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -50,7 +50,7 @@
         "labels": {
           "description": "Key/value pairs that used to specify identifying attributes of images",
           "type": "object",
-          "additionalProperties": {"type": "string"}
+          "additionalProperties": { "type": "string" }
         },
         "mediaType": {
           "description": "The media type of the image",
@@ -61,9 +61,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "image"
-      ],
+      "required": ["image"],
       "type": "object"
     },
     "invocationImage": {
@@ -85,7 +83,7 @@
         "labels": {
           "description": "Key/value pairs that used to specify identifying attributes of invocation images",
           "type": "object",
-          "additionalProperties": {"type": "string"}
+          "additionalProperties": { "type": "string" }
         },
         "mediaType": {
           "description": "The media type of the image",
@@ -96,9 +94,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "image"
-      ],
+      "required": ["image"],
       "type": "object"
     },
     "output": {
@@ -124,10 +120,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "definition",
-        "path"
-      ],
+      "required": ["definition", "path"],
       "type": "object"
     },
     "parameter": {
@@ -163,14 +156,11 @@
         },
         "immutable": {
           "description": "A flag indicating if the parameter value can be changed once it is set",
-          "type" : "boolean",
+          "type": "boolean",
           "default": false
         }
       },
-      "required": [
-        "definition",
-        "destination"
-      ],
+      "required": ["definition", "destination"],
       "type": "object"
     }
   },
@@ -263,9 +253,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "type": "object"
       },
       "type": "array"
@@ -304,7 +292,7 @@
     "requiredExtensions": {
       "description": "A collection of extensions required for this bundle.",
       "type": "array",
-      "additionalProperties": {"type": "string"}
+      "additionalProperties": { "type": "string" }
     },
     "schemaVersion": {
       "description": "The version of the CNAB specification. This should always be the string 'v1' for this schema version.",
@@ -316,12 +304,7 @@
       "type": "string"
     }
   },
-  "required": [
-    "invocationImages",
-    "name",
-    "schemaVersion",
-    "version"
-  ],
+  "required": ["invocationImages", "name", "schemaVersion", "version"],
   "title": "CNAB1 Bundle Descriptor",
   "type": "object"
 }


### PR DESCRIPTION
- a75deff34324bceb3883a1373f6e148df1d93167 Autoformats json with prettier (this was pretty helpful for fixing indentation everywhere)
- f599dcb00350238012ac721b9d02c8e3d42f5e40 Removes the `fields` and `required` properties from `parameters` in favor of `required` property directly on the parameter type.

Closes #222 