### PR TITLE
Make contentDigest required in image JSON schema

### DIFF
--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -61,7 +61,7 @@
           "type": "integer"
         }
       },
-      "required": ["image"],
+      "required": ["image", "contentDigest"],
       "type": "object"
     },
     "invocationImage": {


### PR DESCRIPTION
Right now, it's ambiguous where `contentDigest` should be required or not in an image. This PR makes it required so that we can depend upon it for [CNAB Security](https://github.com/deislabs/cnab-spec/blob/master/300-CNAB-security.md).