### PR TITLE
add a CNAB Security icon

### DIFF
--- a/300-CNAB-security.md
+++ b/300-CNAB-security.md
@@ -5,6 +5,8 @@ weight: 300
 
 # Cloud Native Application Bundles Security (CNAB-Sec) 1.0 WD
 
+![cnab-security](https://user-images.githubusercontent.com/686194/61752644-54580b80-ad61-11e9-9518-608534d09bdd.png)
+
 The CNAB Security specification augments the [CNAB Core specification](100-CNAB.md) by standardizing on security mechanisms for signing, verifying, and attesting CNAB packages. It describes both a client/registry security model and a verification chain (provenance) model. By design, this provides security mechanisms that work in air-gapped networks.
 
 This specification is distinct from the CNAB Core specification. An implementation may comply with the CNAB Core specification, and yet not comply with this specification. The use of terms such as MUST and SHOULD in this document are statements about how a CNAB implementation may fulfill the CNAB Security specification _only_.


### PR DESCRIPTION
![cnab-security](https://user-images.githubusercontent.com/686194/61752680-82d5e680-ad61-11e9-81a6-f8c073c26069.png)

Adds a security icon, which is a variant of the main CNAB logo.