### PR TITLE
add a CNAB Registry icon

### DIFF
--- a/200-CNAB-registries.md
+++ b/200-CNAB-registries.md
@@ -6,6 +6,10 @@ weight: 200
 # CNAB Registries 1.0
 Working Draft, Feb. 2019
 
+![cnab-registry](https://user-images.githubusercontent.com/686194/61753147-2b387a80-ad63-11e9-8a63-f250bcdf06b0.png)
+
+---
+
 This specification describes how CNAB bundles can be stored inside of OCI Registries.
 
 This specification, the CNAB Registries specification, is not part of the CNAB Core specification. An implementation of CNAB Core MAY NOT implement this specification, yet still claim compliance with CNAB Core. A CNAB implementation MUST NOT claim to be CNAB Registries-compliant unless it meets this specification.


### PR DESCRIPTION
![cnab-registry](https://user-images.githubusercontent.com/686194/61753147-2b387a80-ad63-11e9-8a63-f250bcdf06b0.png)

Adds a registry icon, which is a variant of the main CNAB logo.