### PR TITLE
Remove the `immutable` attribute from parameters

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -227,8 +227,7 @@ What follows is an example of a thick bundle. Notice how the `invocationImage` a
       "description": "The port that the backend will listen on",
       "destination": {
         "path": "/path/to/backend_port"
-      },
-      "immutable": true
+      }
     }
   },
   "schemaVersion": "v1.0.0-WD",
@@ -456,7 +455,6 @@ Parameter specifications consist of name/value pairs. The name is fixed, but the
     - `destination`: Indicates where (in the invocation image) the parameter is to be written (REQUIRED)
       - `env`: The name of an environment variable
       - `path`: The fully qualified path to a file that will be created. Specified path MUST NOT be a subpath of `/cnab/app/outputs`.
-    - `immutable`: an immutable parameter may only be set at installation. The value of the parameter cannot be changed. MUST be a boolean. Default value is false. (OPTIONAL).
     - `required`: indicates whether this parameter MUST be supplied. By default it is `false`, which means the parameter is optional. When `true`, a runtime MUST fail if the parameter is not provided for any action to which the parameter applies.
 
 Parameter names (the keys in `parameters`) ought to conform to the [Open Group Base Specification Issue 6, Section 8.1, paragraph 4](http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html) definition of environment variable names with one exception: parameter names MAY begin with a digit (approximately `[A-Z0-9_]+`).
@@ -536,7 +534,6 @@ The structure of a `parameters` and `definitions` section looks like the section
         "env": <string>,
         "path": <string>
       },
-      "immutable" : <boolean>,
       "required" : <boolean>
     }
   }

--- a/103-bundle-runtime.md
+++ b/103-bundle-runtime.md
@@ -137,7 +137,6 @@ The parameter value is evaluated thus:
 - If the parameter is marked `required` and a value is not supplied, the CNAB Runtime MUST produce an error and discontinue action.
 - If the CNAB runtime does not provide a value, but `default` is set, then the default value MUST be used.
 - If no value is provided and `default` is unset, the runtime MUST set the value to an empty string (""), regardless of type.
-- If an immutable parameter value is specified at any time after _install_, the CNAB Runtime MUST produce an error and discontinue action.
 
 > Setting the value of other types to a default value based on type, e.g. Boolean to `false` or integer to `0`, is considered _incorrect behavior_. Setting the value to `null`, `nil`, or a related character string is also considered incorrect.
 

--- a/examples/101.02-bundle.json
+++ b/examples/101.02-bundle.json
@@ -85,8 +85,7 @@
       "description": "The port that the backend will listen on",
       "destination": {
         "path": "/path/to/backend_port"
-      },
-      "immutable": true
+      }
     }
   },
   "schemaVersion": "v1.0.0-WD",

--- a/schema/bundle.schema.json
+++ b/schema/bundle.schema.json
@@ -154,11 +154,6 @@
           },
           "type": "object"
         },
-        "immutable": {
-          "description": "A flag indicating if the parameter value can be changed once it is set",
-          "type": "boolean",
-          "default": false
-        },
         "required": {
           "default": false,
           "description": "Indicates whether this parameter must be supplied. By default, parameters are optional.",


### PR DESCRIPTION
This removes the `immutable` attribute from parameters per Issue #229

Closes #229 