### PR TITLE
fix(claim.schema.json): s/underay/underway

### DIFF
--- a/schema/claim.schema.json
+++ b/schema/claim.schema.json
@@ -17,7 +17,7 @@
           "enum": [
             "failure",
             "success",
-            "underay",
+            "underway",
             "unknown"
           ],
           "type": "string"


### PR DESCRIPTION
Fixes misspelling of the `underway` status on the claim spec