### PR TITLE
fix(claim.schema.json): s/descripton/description

### DIFF
--- a/schema/claim.schema.json
+++ b/schema/claim.schema.json
@@ -13,7 +13,7 @@
           "type": "string"
         },
         "status": {
-          "descripton": "The status of the last action",
+          "description": "The status of the last action",
           "enum": [
             "failure",
             "success",


### PR DESCRIPTION
Fixes misspelling of the `description` field under `status`.