### PR TITLE
Final Approval for CNAB Core 1.0 Specification

### DIFF
--- a/100-CNAB.md
+++ b/100-CNAB.md
@@ -4,7 +4,7 @@ weight: 100
 ---
 
 # Cloud Native Application Bundle Core 1.0.0 (CNAB1)
-*[Working Draft](901-process.md), Nov. 2018*
+*[Final Approval, Published](901-process.md), Sept., 2019*
 
 
 The Cloud Native Application Bundle (CNAB) is a _standard packaging format_ for multi-component distributed applications. It allows packages to target different runtimes and architectures. It empowers application distributors to package applications for deployment on a wide variety of cloud platforms, providers, and services. Furthermore, it provides necessary capabilities for delivering multi-container applications in disconnected (airgapped) environments.

--- a/100-CNAB.md
+++ b/100-CNAB.md
@@ -4,7 +4,7 @@ weight: 100
 ---
 
 # Cloud Native Application Bundle Core 1.0.0 (CNAB1)
-*[Final Approval, Published](901-process.md), Sept., 2019*
+*[Final Approval, Published](901-process.md), Sept. 2019*
 
 
 The Cloud Native Application Bundle (CNAB) is a _standard packaging format_ for multi-component distributed applications. It allows packages to target different runtimes and architectures. It empowers application distributors to package applications for deployment on a wide variety of cloud platforms, providers, and services. Furthermore, it provides necessary capabilities for delivering multi-container applications in disconnected (airgapped) environments.

--- a/901-process.md
+++ b/901-process.md
@@ -11,7 +11,7 @@ This process governs the motion of a specification from rough draft through full
 
 Specifications shall each track their own versions. A specification will call out a target version (such as 1.0), and then also include its phase (such as Pre-Draft, see below) to indicate progress towards the target version.
 
-For example, one of the specifications in this repository is the CNAB Core specification. The CNAB Core specification should be formally referenced as _Cloud Native Application Bundle Core 1.0.0_. The phase of the process MAY be appended as a stability marker: _Cloud Native Application Bundle Core 1.0.0-Draft_. It MAY be abbreviated to _CNAB1_ or _CNAB1-Draft_.
+For example, one of the specifications in this repository is the CNAB Core specification. The CNAB Core specification should be formally referenced as _Cloud Native Application Bundle Core 1.0.0_. The phase of the process MAY be appended as a stability marker: _Cloud Native Application Bundle Core 1.0.0-FA_. It MAY be abbreviated to _CNAB1_ or _CNAB1-FA_.
 
 Other specifications must follow the same nomenclature.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Cloud Native Application Bundles (CNAB) are a package format specification that 
 
 ## CNAB Core 1.0 (Final)
 
-The CNAB Working Group with the joint approval of the Executive Directors have approved the CNAB Core 1.0 specification for publication. CNAB Core 1.0 is complete.
+The CNAB Working Group with the joint approval of the Executive Directors has approved the CNAB Core 1.0 specification for publication. CNAB Core 1.0 is complete.
 
 For more information on the approval process, see [the process documentation](901-process.md). Further changes to CNAB Core will be considered for CNAB Core 1.1.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 Cloud Native Application Bundles (CNAB) are a package format specification that describes a technology for bundling, installing, and managing distributed applications, that are by design, cloud agnostic.
 
-## CNAB Core 1.0 GA
+## CNAB Core 1.0 (Final)
 
-The CNAB Working Group has approved the CNAB Core 1.0 specification. This specification is now pending approval from the CNAB Foundation executive committee, after which it will be finalized as CNAB Core 1.0 (AD). For more information on the approval process, see [the process documentation](901-process.md). Further changes to CNAB Core will be considered for CNAB Core 1.1.
+The CNAB Working Group with the joint approval of the Executive Directors have approved the CNAB Core 1.0 specification for publication. CNAB Core 1.0 is complete.
+
+For more information on the approval process, see [the process documentation](901-process.md). Further changes to CNAB Core will be considered for CNAB Core 1.1.
 
 ## Table of Contents
 


### PR DESCRIPTION
This commit indicates that the CNAB specification is now a published final version.

This requires unanimous approval from the executive directors. The following people MUST mark this LGTM:

@chris-crone 
@technosophos

When this PR is merged, the tag `cnab-core-1.0` should be created in Git. 

As with any other PR, all are welcomed to review this PR for grammar, wording, spelling, and technical correctness.