### PR TITLE
Bump bundle schemaVersion to v1.0.0

### DIFF
--- a/101-bundle-json.md
+++ b/101-bundle-json.md
@@ -13,7 +13,7 @@ The `bundle.json` file is a representation of bundle metadata. It MUST be repres
 
 A `bundle.json` is broken down into the following categories of information:
 
-- The schema version of the bundle, as a string with a `v` prefix. This schema is to be referenced as `v1` or `v1.0.0-WD`
+- The schema version of the bundle, as a string with a `v` prefix. This schema is to be referenced as `v1` or `v1.0.0`
 - The top-level package information (`name` and `version`)
   - `name`: The bundle name, including namespacing. The namespace can have one or more elements separated by a dot (e.g. `acme.tunnels.wordpress`). The left most element of the namespace is the most general moving toward more specific elements on the right.
   - `version`: Semantic version of the bundle
@@ -123,7 +123,7 @@ The following is an example of a `bundle.json` for a bundled distributed as a _t
          }
       }
    },
-   "schemaVersion":"v1.0.0-WD",
+   "schemaVersion":"v1.0.0",
    "version":"0.1.2"
 }
 ```
@@ -134,7 +134,7 @@ The canonical JSON version of the above is:
 
 <!-- prettier-ignore -->
 ```json
-{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"},"port":{"maximum":65535,"minimum":1024,"type":"integer"},"string":{"type":"string"},"x509Certificate":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","type":"string","writeOnly":true}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"technosophos/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"clientCert":{"definition":"x509Certificate","path":"/cnab/app/outputs/clientCert"},"hostName":{"applyTo":["install"],"definition":"string","description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname"},"port":{"definition":"port","path":"/cnab/app/outputs/port"}},"parameters":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}},"schemaVersion":"v1.0.0-WD","version":"0.1.2"}
+{"credentials":{"hostkey":{"env":"HOST_KEY","path":"/etc/hostkey.txt"}},"custom":{"com.example.backup-preferences":{"frequency":"daily"},"com.example.duffle-bag":{"icon":"https://example.com/icon.png","iconType":"PNG"}},"definitions":{"http_port":{"default":80,"maximum":10240,"minimum":10,"type":"integer"},"port":{"maximum":65535,"minimum":1024,"type":"integer"},"string":{"type":"string"},"x509Certificate":{"contentEncoding":"base64","contentMediaType":"application/x-x509-user-cert","type":"string","writeOnly":true}},"description":"An example 'thin' helloworld Cloud-Native Application Bundle","images":{"my-microservice":{"contentDigest":"sha256:aaaaaaaaaaaa...","description":"my microservice","image":"technosophos/microservice:1.2.3"}},"invocationImages":[{"contentDigest":"sha256:aaaaaaa...","image":"technosophos/helloworld:0.1.0","imageType":"docker"}],"maintainers":[{"email":"matt.butcher@microsoft.com","name":"Matt Butcher","url":"https://example.com"}],"name":"helloworld","outputs":{"clientCert":{"definition":"x509Certificate","path":"/cnab/app/outputs/clientCert"},"hostName":{"applyTo":["install"],"definition":"string","description":"the hostname produced installing the bundle","path":"/cnab/app/outputs/hostname"},"port":{"definition":"port","path":"/cnab/app/outputs/port"}},"parameters":{"backend_port":{"definition":"http_port","description":"The port that the back-end will listen on","destination":{"env":"BACKEND_PORT"}}},"schemaVersion":"v1.0.0","version":"0.1.2"}
 ```
 
 What follows is an example of a thick bundle. Notice how the `invocationImage` and `images` fields reference the underlying docker image manifest (`application/vnd.docker.distribution.manifest.v2+json`), which in turn references the underlying images:
@@ -230,7 +230,7 @@ What follows is an example of a thick bundle. Notice how the `invocationImage` a
          }
       }
    },
-   "schemaVersion":"v1.0.0-WD",
+   "schemaVersion":"v1.0.0",
    "version":"1.0.0"
 }
 
@@ -266,8 +266,9 @@ The schema version must reference the version of the schema used for this docume
 
 - `WD` indicates that the document references a working draft of the specification, and is not considered stable.
 - `CR` indicates that the document references a candidate recommendation. Stability is not assured.
+- No suffix indicates that the document references a release of the specification, and is considered stable.
 
-The current schema version is `v1.0.0-WD`, which is considered unstable.
+The current schema version is `v1.0.0`, which is considered stable.
 
 ## Name and Version: Identifying Metadata
 
@@ -926,7 +927,7 @@ A runtime MUST check that it supports any required extensions before performing 
    "requiredExtensions":[ 
       "io.cnab.dependencies"
    ],
-   "schemaVersion":"v1.0.0-WD",
+   "schemaVersion":"v1.0.0",
    "version":"0.1.2"
 }
 ```

--- a/400-claims.md
+++ b/400-claims.md
@@ -68,7 +68,7 @@ The CNAB claim is defined as a JSON document. The specification currently does n
     "name": "technosophos.hellohelm",
     "outputs": {},
     "parameters": {},
-    "schemaVersion": "v1.0.0-WD",
+    "schemaVersion": "v1.0.0",
     "version": "0.1.0"
   },
   "created": "2018-08-30T20:39:55.549002887-06:00",
@@ -165,7 +165,7 @@ Below, you can see an example of a claim for a bundle that included a single out
     "parameters":{ 
 
     },
-    "schemaVersion":"v1.0.0-WD",
+    "schemaVersion":"v1.0.0",
     "version":"0.1.0"
   },
   "created": "2018-08-30T20:39:55.549002887-06:00",

--- a/examples/101.01-bundle.json
+++ b/examples/101.01-bundle.json
@@ -86,6 +86,6 @@
       }
     }
   },
-  "schemaVersion": "v1.0.0-WD",
+  "schemaVersion": "v1.0.0",
   "version": "0.1.2"
 }

--- a/examples/101.02-bundle.json
+++ b/examples/101.02-bundle.json
@@ -88,6 +88,6 @@
       }
     }
   },
-  "schemaVersion": "v1.0.0-WD",
+  "schemaVersion": "v1.0.0",
   "version": "1.0.0"
 }

--- a/examples/101.03-bundle.json
+++ b/examples/101.03-bundle.json
@@ -100,6 +100,6 @@
   "requiredExtensions": [
     "io.cnab.dependencies"
   ],
-  "schemaVersion": "v1.0.0-WD",
+  "schemaVersion": "v1.0.0",
   "version": "0.1.2"
 }

--- a/examples/400.01-claim.json
+++ b/examples/400.01-claim.json
@@ -10,7 +10,7 @@
     ],
     "name": "technosophos.hellohelm",
     "parameters": {},
-    "schemaVersion": "v1.0.0-WD",
+    "schemaVersion": "v1.0.0",
     "version": "0.1.0"
   },
   "created": "2018-08-30T20:39:55.549002887-06:00",


### PR DESCRIPTION
As part of the Core 1.0 release, we did not bump the bundle schemaVersion from v1.0.0-WD to v1.0.0.

cc @rumpl who caught this.